### PR TITLE
Improved export_recon_hdf5() and implement import_recon_hdf5()

### DIFF
--- a/docs/source/usr_utilities.rst
+++ b/docs/source/usr_utilities.rst
@@ -27,3 +27,5 @@ The functions here are for direct interactions with files.
 .. autofunction:: mbirjax.utilities.download_and_extract_tar
 .. autofunction:: mbirjax.utilities.save_data_hdf5
 .. autofunction:: mbirjax.utilities.load_data_hdf5
+.. autofunction:: mbirjax.utilities.export_recon_hdf5
+.. autofunction:: mbirjax.utilities.import_recon_hdf5

--- a/mbirjax/preprocess/utilities.py
+++ b/mbirjax/preprocess/utilities.py
@@ -534,29 +534,19 @@ def apply_cylindrical_mask(recon, radial_margin, top_margin, bottom_margin):
 
 def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=True, radial_margin=10, top_margin=10, bottom_margin=10):
     """
-      Export a 3-D reconstruction volume to an HDF5 file with optional post-processing.
+    Export a 3D reconstruction volume to an HDF5 file with optional post-processing.
 
-      The function can (1) **flip axes** from ``(row, col, slice) → (slice, row, col)``,
-      and (2) remove flash artifacts via a cylindrical mask before saving.
-      Any key–value metadata in *recon_dict* is written as HDF5 attributes so it can
-      later be retrieved with :func:`load_data_hdf5`.
+    This function transposes the input volume to right-hand coordinates (slice, row, col), optionally applies a cylindrical
+    mask to remove flash artifacts, and writes the volume and metadata to an HDF5 file.
 
-      Parameters
-      ----------
-       file_path (str): Full path to the output HDF5 file. Directories will be created if they do not exist.
-       recon (numpy.ndarray | jax.Array): 3-D volume in left-hand order ``(row, col, slice)``.  Will be converted to NumPy
-       just before writing because *h5py* cannot accept JAX arrays.
-       recon_dict (dict, optional): Dictionary of attributes to store as metadata in the dataset.
-       flip_coordinates (bool): If *True*, reorder axes to ``(slice, row, col)`` (right-hand slice-first) before saving.
-
-       remove_flash (bool): If *True*, apply :func:`apply_cylindrical_mask` with the margins below.
-       radial_margin (int): Margin to subtract from the cylinder radius in pixels.
-       top_margin (int): Number of top slices to set to zero along the Z-axis.
-       bottom_margin (int): Number of bottom slices to set to zero along the Z-axis.
-
-       Notes
-       -----
-       If *remove_flash* is ``False`` the margin arguments are ignored.
+    Args:
+        file_path (str): Full path to the output HDF5 file. Parent directories will be created if they do not exist.
+        recon (np.ndarray | jax.Array): 3D volume in (row, col, slice) order. Will be converted to NumPy before writing.
+        recon_dict (dict, optional): Dictionary of attributes to store as metadata in the dataset.
+        remove_flash (bool, optional): Whether to apply a cylindrical mask to remove peripheral and top/bottom slices. Defaults to True.
+        radial_margin (int): Margin to subtract from the cylinder radius in pixels. Defaults to 10.
+        top_margin (int): Number of top slices to set to zero along the Z-axis. Defaults to 10.
+        bottom_margin (int): Number of bottom slices to set to zero along the Z-axis. Defaults to 10.
     """
 
     recon = jnp.asarray(recon)
@@ -572,18 +562,18 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=True, radi
 
 def import_recon_hdf5(file_path):
     """
-    Import a reconstruction volume from an HDF5 file with optional preprocessing.
+    Import a 3D reconstruction volume from an HDF5 file.
 
-    This function loads a reconstruction volume and associated metadata from an HDF5 file, with options for flipping
-    axes, removing flash artifacts, and applying a cylindrical mask to trim peripheral and top/bottom regions.
+    This function loads a reconstruction volume and associated metadata, and reorders axes
+    from (slice, row, col) to (row, col, slice).
 
     Args:
-        file_path (str): Path to the HDF5 file containing the reconstructed volume.
+        file_path (str): Path to the HDF5 file containing the reconstruction volume.
 
     Returns:
-        tuple: (recon, recon_dict)
-            - recon (ndarray): The processed 3D reconstruction volume.
-            - recon_dict (dict): Metadata dictionary loaded from the HDF5 file.
+        Tuple[np.ndarray, dict]: Tuple containing:
+            - recon: The reconstructed 3D volume in (row, col, slice) order.
+            - recon_dict: Metadata dictionary loaded from the HDF5 file.
     """
     recon, recon_dict = load_data_hdf5(file_path)
 

--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -3,6 +3,7 @@ import os, sys
 # === Core scientific/plotting libraries ===
 import matplotlib.pyplot as plt
 import numpy as np
+import jax.numpy as jnp
 
 # === Project-specific imports ===
 import mbirjax as mj
@@ -429,11 +430,11 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=True, radi
     recon = jnp.transpose(recon, (2, 0, 1))
 
     if remove_flash:
-        recon = apply_cylindrical_mask(recon=recon, radial_margin=radial_margin, top_margin=top_margin, bottom_margin=bottom_margin)
+        recon = mj.preprocess.apply_cylindrical_mask(recon=recon, radial_margin=radial_margin, top_margin=top_margin, bottom_margin=bottom_margin)
 
     recon = np.array(recon)
 
-    save_data_hdf5(file_path=file_path, recon=recon,array_name='recon', attributes_dict=recon_dict)
+    save_data_hdf5(file_path=file_path, array=recon, array_name='recon', attributes_dict=recon_dict)
 
 
 def import_recon_hdf5(file_path):

--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -427,14 +427,14 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=True, radi
     """
 
     recon = jnp.asarray(recon)
-    recon = jnp.transpose(recon, (2, 0, 1))
 
     if remove_flash:
-        recon = mj.preprocess.apply_cylindrical_mask(recon=recon, radial_margin=radial_margin, top_margin=top_margin, bottom_margin=bottom_margin)
+        recon = mj.preprocess.apply_cylindrical_mask(recon, radial_margin, top_margin, bottom_margin)
 
+    recon = jnp.transpose(recon, (2, 0, 1))
     recon = np.array(recon)
 
-    save_data_hdf5(file_path=file_path, array=recon, array_name='recon', attributes_dict=recon_dict)
+    save_data_hdf5(file_path, recon, 'recon', recon_dict)
 
 
 def import_recon_hdf5(file_path):

--- a/tests/function_test_export_import.py
+++ b/tests/function_test_export_import.py
@@ -20,23 +20,27 @@ export_recon_hdf5(file_path=file_path, recon=phantom,
                   radial_margin=10, top_margin=8, bottom_margin=6)
 
 # 3. Import from HDF5
-exported_recon = mj.utilities.load_data_hdf5(file_path)
+exported_recon, _ = mj.utilities.load_data_hdf5(file_path) # Load using the standard function
 
 imported_recon, recon_dict = import_recon_hdf5(file_path)
 
 # 4. Verify equivalence
+
+# Expected behaviour: The phantom on the right is flash-removed and flipped to right hand coordnidates.
 mj.slice_viewer(
     phantom,
     exported_recon,
     slice_axis=0,
-    slice_label=["Original Phantom", "Exported Phantom: Flash Removed & Flipped"],
-    title="Shepp-Logan: Original vs Imported"
+    slice_label=["Original Phantom (row, col, slice)", "Exported Phantom: Flash Removed & Flipped (slice, row, col)"],
+    title="Shepp-Logan: Original vs Exported"
 )
+
+# Expected behaviour: Two phantoms should look similar, except the right one is flash-removed.
 
 mj.slice_viewer(
     phantom,
     imported_recon,
-    slice_axis=0,
+    slice_axis=2,
     slice_label=["Original Phantom", "Imported Phantom: Flash Removed & Flipped Back"],
     title="Shepp-Logan: Original vs Imported"
 )

--- a/tests/function_test_export_import.py
+++ b/tests/function_test_export_import.py
@@ -1,0 +1,42 @@
+# dev_scripts/test_export_hdf5.py
+import os
+
+import h5py
+import numpy as np
+import mbirjax as mj
+from mbirjax.utilities import export_recon_hdf5, import_recon_hdf5
+
+# 1. Generate synthetic Shepp-Logan phantom
+
+phantom, _, _ = mj.generate_demo_data(object_type='shepp-logan', model_type='parallel', num_views=64, num_det_rows=40, num_det_channels=128)
+
+# 2. Export to fixed output path
+output_dir = ".output"
+os.makedirs(output_dir, exist_ok=True)
+file_path = os.path.join(output_dir, "test_shepp_logan_export.h5")
+
+export_recon_hdf5(file_path=file_path, recon=phantom,
+                  recon_dict={"phantom": "shepp-logan", "test": "roundtrip"}, remove_flash=True,
+                  radial_margin=10, top_margin=8, bottom_margin=6)
+
+# 3. Import from HDF5
+exported_recon = mj.utilities.load_data_hdf5(file_path)
+
+imported_recon, recon_dict = import_recon_hdf5(file_path)
+
+# 4. Verify equivalence
+mj.slice_viewer(
+    phantom,
+    exported_recon,
+    slice_axis=0,
+    slice_label=["Original Phantom", "Exported Phantom: Flash Removed & Flipped"],
+    title="Shepp-Logan: Original vs Imported"
+)
+
+mj.slice_viewer(
+    phantom,
+    imported_recon,
+    slice_axis=0,
+    slice_label=["Original Phantom", "Imported Phantom: Flash Removed & Flipped Back"],
+    title="Shepp-Logan: Original vs Imported"
+)

--- a/tests/function_test_export_import.py
+++ b/tests/function_test_export_import.py
@@ -1,6 +1,5 @@
 # dev_scripts/test_export_hdf5.py
 import os
-
 import h5py
 import numpy as np
 import mbirjax as mj
@@ -26,7 +25,7 @@ imported_recon, recon_dict = import_recon_hdf5(file_path)
 
 # 4. Verify equivalence
 
-# Expected behaviour: The phantom on the right is flash-removed and flipped to right hand coordnidates.
+# Expected behaviour: The phantom on the right is flash-removed and flipped to right hand coordinates.
 mj.slice_viewer(
     phantom,
     exported_recon,


### PR DESCRIPTION
This PR introduces two utility functions:

- `export_recon_hdf5()`:
  - Converts a 3D volume from (row, col, slice) to (slice, row, col) format.
  - Optionally applies a cylindrical mask to suppress flash artifacts.
  - Saves the volume and optional metadata to HDF5.
  - Improved docstring and in now in mbirjax/ preprocess/ utilities.py

- `import_recon_hdf5()`:
  - Loads a volume from HDF5 and restores it to (row, col, slice) order.
  - Returns both the reconstruction and associated metadata.