### PR TITLE
Bug fix in download_and_extract()

### DIFF
--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -401,7 +401,12 @@ def download_and_extract(download_url, save_dir):
                 actual_filename = f.read().strip()
             file_path = os.path.join(save_dir, actual_filename)
             filename = actual_filename
-            is_download = False
+
+            if os.path.exists(file_path):
+                is_download = False
+            else:
+                is_download = True
+
         else:
             filename = f"gdrive_{file_id}"
             is_download = True


### PR DESCRIPTION
-Problem: When a user deletes the original file but leaves the marker file, the function incorrectly assumes the file still exists. As a result, it skips the download process and raises a “file not found” error.

- Solution: Updated the function to check for the presence of both the marker file and the actual file before deciding to skip the download.