### PR TITLE
Improved code structure, subspace basis estimation, and default batch size

### DIFF
--- a/mbirjax/hsnt.py
+++ b/mbirjax/hsnt.py
@@ -13,7 +13,7 @@ from sklearn.utils.extmath import randomized_svd
 
 
 def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, subspace_basis=None, safety_factor=2,
-                  batch_size=2 ** 24, beta_loss='frobenius', max_iter=300, tolerance=1e-6, verbose=1):
+                  batch_size=2 ** 27, beta_loss='frobenius', max_iter=300, tolerance=1e-6, verbose=1):
     """
     Denoise a hyperspectral dataset using dehydration and rehydration.
 
@@ -76,7 +76,7 @@ def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, sub
 
 
 def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspace_basis=None, safety_factor=2,
-              batch_size=2 ** 24, beta_loss='frobenius', max_iter=300, tolerance=1e-6, verbose=1):
+              batch_size=2 ** 27, beta_loss='frobenius', max_iter=300, tolerance=1e-6, verbose=1):
     """
     Dehydrate/compress a hyperspectral dataset onto a low-dimensional subspace.
 


### PR DESCRIPTION
1. Moved the batch processing routine inside dehydrate.
        -Makes the separate use of dehydrate easier.
        -Also would help when we develop fast_hyper_recon() function.

2. Improved the subspace basis estimation for multi-batch data.
        -Based on the algorithm I presented.

3. Increased the default batch size to 2 ** 27.
       -Since the data is float64, a batch_size of 2 ** 27 would make each batch 1 GB.

Test code by running mbirjax/experiments/hsnt/example_2_denoise_real_data.py