### PR TITLE
Switch export_recon_hdf5 to NumPy to avoid GPU out-of-memory issue

### DIFF
--- a/experiments/zeiss/Cone_beam_exp_ORNL.py
+++ b/experiments/zeiss/Cone_beam_exp_ORNL.py
@@ -57,6 +57,11 @@ def main():
     else:
         mbir_recon, recon_dict = ct_model.recon(sinogram, weights=weights)
 
+    # Convert MBIR Recon to unit of mm^-1
+    if metadata['ALU_unit'] == 'um':
+        direct_recon *= 1000
+        mbir_recon *= 1000
+
     # Save recon to hdf5
     print("\n*********** save mbir and fdk recon in h5 format *************")
     os.makedirs(output_path, exist_ok=True)  # mkdir if directory does not exist

--- a/experiments/zeiss/Cone_beam_exp_ORNL.py
+++ b/experiments/zeiss/Cone_beam_exp_ORNL.py
@@ -52,7 +52,10 @@ def main():
 
     # Perform MBIR reconstruction
     print("\n********** Perform MBIR reconstruction **************")
-    mbir_recon, recon_dict = ct_model.recon(sinogram, weights=weights)
+    if downsample_factor == 1:
+        mbir_recon, recon_dict = ct_model.split_sino_recon(sinogram, weights=weights)
+    else:
+        mbir_recon, recon_dict = ct_model.recon(sinogram, weights=weights)
 
     # Save recon to hdf5
     print("\n*********** save mbir and fdk recon in h5 format *************")

--- a/mbirjax/preprocess/utilities.py
+++ b/mbirjax/preprocess/utilities.py
@@ -528,8 +528,7 @@ def project_vector_to_vector(u1, u2):
     u1_proj = np.dot(u1, u2)*u2
     return u1_proj
 
-from functools import partial
-@partial(jax.jit, static_argnames=['top_margin', 'bottom_margin'])
+
 def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0):
     """
     Applies a cylindrical mask to a 3D reconstruction volume.
@@ -564,7 +563,7 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
     radius = base_radius - radial_margin
 
     # Create circular mask in (row, col) plane
-    row_coords, col_coords = jnp.meshgrid(jnp.arange(num_recon_rows), jnp.arange(num_recon_cols), indexing='ij')
+    row_coords, col_coords = np.meshgrid(np.arange(num_recon_rows), np.arange(num_recon_cols), indexing='ij')
     dist_sq = (row_coords - row_center) ** 2 + (col_coords - col_center) ** 2
     circular_mask = (dist_sq <= radius ** 2).astype(recon.dtype)
 
@@ -573,9 +572,9 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
 
     # Zero out top and bottom slices along Z
     if top_margin > 0:
-        recon = recon.at[:, :, :top_margin].set(0)
+        recon[:, :, :top_margin] = 0
     if bottom_margin > 0:
-        recon = recon.at[:, :, -bottom_margin:].set(0)
+        recon[:, :, -bottom_margin:] = 0
 
     return recon
 

--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -574,19 +574,15 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, rad
         >>> export_recon_hdf5("output/recon_volume.h5", recon, recon_dict={"scan_id": "sample1"})
     """
 
-    @jax.jit
-    def process_recon(local_recon):
+    recon = np.asarray(jax.device_get(recon))
 
-        if remove_flash:
-            local_recon = mj.preprocess.apply_cylindrical_mask(local_recon, radial_margin, top_margin, bottom_margin)
+    if remove_flash:
+        recon = mj.preprocess.apply_cylindrical_mask(recon, radial_margin, top_margin, bottom_margin)
 
-        # Convert to right-handed coordinate system
-        local_recon = jnp.transpose(local_recon, (2, 1, 0))
-        local_recon = jax.device_get(local_recon)
-        return local_recon
+    # Convert to right-handed coordinate system
+    recon = np.transpose(recon, (2, 1, 0))
 
-    recon = jax.device_get(recon)
-    recon = process_recon(recon)
+    # Save the recon
     save_data_hdf5(file_path, recon, 'recon', recon_dict)
 
 


### PR DESCRIPTION
This PR includes the following updates:

- Replace all JAX-based code in export_recon_hdf5 with NumPy to prevent GPU out-of-memory issues when saving large recon volumes.

- Include full resolution reconstruction for ORNL txrm data using split sino

- Change the unit of ORNL txrm data reconstruction to 1/mm