### PR TITLE
ALU unit conversion for NSI recon

### DIFF
--- a/mbirjax/preprocess/nsi.py
+++ b/mbirjax/preprocess/nsi.py
@@ -405,13 +405,13 @@ def convert_nsi_to_mbirjax_params(nsi_params, downsample_factor=(1, 1), crop_pix
     delta_det_row *= downsample_factor[0]
     delta_det_channel *= downsample_factor[1]
 
-    # Set 1 ALU = delta_det_channel
-    source_detector_dist /= delta_det_channel # mm to ALU
-    source_iso_dist /= delta_det_channel # mm to ALU
-    det_channel_offset /= delta_det_channel # mm to ALU
-    det_row_offset /= delta_det_channel # mm to ALU
-    delta_det_row /= delta_det_channel
-    delta_det_channel = 1.0
+
+    # Set 1 ALU = 1 mm
+    source_detector_dist /= 1.0 # mm to ALU
+    source_iso_dist /= 1.0 # mm to ALU
+    det_channel_offset /= 1.0 # mm to ALU
+    det_row_offset /= 1.0 # mm to ALU
+    delta_det_row /= 1.0 # mm to ALU
 
     # Create a dictionary to store MBIR parameters
     num_views = len(angles)
@@ -428,6 +428,8 @@ def convert_nsi_to_mbirjax_params(nsi_params, downsample_factor=(1, 1), crop_pix
     optional_params["det_channel_offset"] = det_channel_offset
     optional_params["det_row_offset"] = det_row_offset
     optional_params["det_rotation"] = det_rotation # tilt angle of rotation axis
+    optional_params['alu_units'] = 'mm'
+    optional_params['alu_value'] = 1.0
 
     return cone_beam_params, optional_params
 


### PR DESCRIPTION
Change 1 ALU = 1 mm for NSI recon (before 1 ALU = delta_det_channel).

I used the demo_fdk_mbir_compare.py script in the mbirjax_applications for testing and the alu units and value are now in the mbir_recon_dict.