### PR TITLE
Fix out-of-memory issue in export_recon_hdf5 when saving large reconstructions

### DIFF
--- a/experiments/preprocessing/export_recon_hdf5_test.py
+++ b/experiments/preprocessing/export_recon_hdf5_test.py
@@ -7,11 +7,12 @@ import os
 import numpy as np
 import time
 import jax
+import jax.numpy as jnp
 import mbirjax as mj
 import warnings
 
 # Volume shape parameters
-factor = 3
+factor = 2
 num_rows = 1024 * factor
 num_cols = 1024 * factor
 num_slices = 1024 * factor
@@ -46,6 +47,7 @@ try:
         top_margin=10,
         bottom_margin=10
     )
+    masked_full = jnp.transpose(masked_full, (2, 1, 0))
     masked_full = masked_full.block_until_ready()
     elapsed_time = time.time() - start_time
     masked_full = jax.device_get(masked_full)
@@ -63,109 +65,39 @@ except Exception as e:
         warnings.warn(f"Test 1 failed: {type(e).__name__}: {e}. Skipping comparison.", RuntimeWarning)
     run_comparison = False
 
-mj.slice_viewer(test_volume, masked_full)
-# Test with slice_start and total_slices (batch processing)
-print("\nTest 2: Batch processing with slice_start and total_slices")
-batch_result = np.zeros_like(test_volume)
-batch_size = batch_size
-
-for start in range(0, num_slices, batch_size):
-    end = min(start + batch_size, num_slices)
-    batch = test_volume[:, :, start:end]
-
-    print(f"  Processing slices {start}-{end - 1} (slice_start={start}, total_slices={num_slices})")
-
-    masked_batch = mj.preprocess.apply_cylindrical_mask(
-        batch,
-        radial_margin=10,
-        top_margin=10,
-        bottom_margin=10,
-        slice_start=start,
-        total_slices=num_slices
-    )
-
-    batch_result[:, :, start:end] = masked_batch
-
-# Compare results
-if run_comparison:
-    max_diff = np.max(np.abs(masked_full - batch_result))
-    print(f"\nMax difference between full and batch: {max_diff}")
-    if max_diff < 1e-6:
-        print("✓ Batch processing matches full volume processing!\n")
-    else:
-        print("✗ WARNING: Batch processing does NOT match full volume processing!\n")
-else:
-    print("\n Comparison skipped (full volume test did not complete)\n")
-
-
-# Test error handling: only slice_start provided
-print("\nTest 3: Error handling - only slice_start provided (should raise ValueError)")
-try:
-    batch = test_volume[:, :, :batch_size]
-    masked_batch = mj.preprocess.apply_cylindrical_mask(
-        batch,
-        radial_margin=10,
-        top_margin=10,
-        bottom_margin=10,
-        slice_start=0,
-        total_slices=None
-    )
-    print("✗ ERROR: Should have raised ValueError but did not!\n")
-except ValueError as e:
-    print(f"✓ Correctly raised ValueError: {e}\n")
-except Exception as e:
-    print(f"✗ ERROR: Raised unexpected exception: {type(e).__name__}: {e}\n")
-
-
-# Test error handling: only total_slices provided
-print("\nTest 4: Error handling - only total_slices provided (should raise ValueError)")
-try:
-    batch = test_volume[:, :, :batch_size]
-    masked_batch = mj.preprocess.apply_cylindrical_mask(
-        batch,
-        radial_margin=10,
-        top_margin=10,
-        bottom_margin=10,
-        slice_start=None,
-        total_slices=num_slices
-    )
-    print("✗ ERROR: Should have raised ValueError but did not!\n")
-except ValueError as e:
-    print(f"✓ Correctly raised ValueError: {e}\n")
-except Exception as e:
-    print(f"✗ ERROR: Raised unexpected exception: {type(e).__name__}: {e}\n")
+mj.slice_viewer(test_volume, masked_full, slice_axis=0)
 
 
 # ============================================================================
 # Test export_recon_hdf5 with batch_size parameter
 # ============================================================================
 print("=" * 70)
-print("Testing export_recon_hdf5 with batch_size parameter")
+print("Testing export_recon_hdf5")
 print("=" * 70)
 
-# Test cases with different batch_size values
-batch_sizes = [16, 32, 64, 128, 256, 512, 1024]
+file_path = os.path.join(output_path, f"test_export_recon.h5")
 
-print(f"\nRunning {len(batch_sizes)} test cases with different batch_size:\n")
+t0 = time.time()
+mj.export_recon_hdf5(
+    file_path,
+    test_volume,
+    recon_dict=None,
+    remove_flash=True,
+    radial_margin=10,
+    top_margin=10,
+    bottom_margin=10,
+)
+t1 = time.time()
+print(f"  Time to save: {t1 - t0:.1f}s\n")
 
-for i, batch_size in enumerate(batch_sizes, 1):
-    print(f"Test {i}/{len(batch_sizes)}: batch_size={batch_size}")
+t0 = time.time()
+loaded_volume, loaded_dict = mj.load_data_hdf5(file_path)
+t1 = time.time()
+print(f"  Time to load: {t1 - t0:.1f}s\n")
 
-    file_path = os.path.join(output_path, f"test_batch_{batch_size}.h5")
-
-    t0 = time.time()
-    mj.export_recon_hdf5(
-        file_path,
-        test_volume,
-        recon_dict=None,
-        remove_flash=True,
-        radial_margin=10,
-        top_margin=10,
-        bottom_margin=10,
-        batch_size=batch_size
-    )
-    t1 = time.time()
-    print(f"  Elapsed: {t1 - t0:.1f}s\n")
+max_diff = np.amax(np.abs(masked_full - loaded_volume))
+print(f"Max difference: {max_diff:.3f}\n")
+mj.slice_viewer(masked_full, loaded_volume, slice_axis=0)
 
 print("=" * 70)
 print("All tests completed!")

--- a/experiments/preprocessing/export_recon_hdf5_test.py
+++ b/experiments/preprocessing/export_recon_hdf5_test.py
@@ -23,7 +23,7 @@ test_volume = np.random.rand(num_rows, num_cols, num_slices).astype(np.float32)
 print(f"Test volume: {test_volume.shape}, {test_volume.nbytes / (1024 ** 3):.3f} GB\n")
 
 # Output directory
-output_path = '/home/yang1581/Data/test_export/'
+output_path = './test_export/'
 os.makedirs(output_path, exist_ok=True)
 
 # ============================================================================

--- a/experiments/preprocessing/export_recon_hdf5_test.py
+++ b/experiments/preprocessing/export_recon_hdf5_test.py
@@ -11,15 +11,16 @@ import mbirjax as mj
 import warnings
 
 # Volume shape parameters
-num_rows = 1024
-num_cols = 1024
-num_slices = 1024
+factor = 3
+num_rows = 1024 * factor
+num_cols = 1024 * factor
+num_slices = 1024 * factor
 
 # Define batch size for testing apply_cylindrical_mask
 batch_size = 64
 
 # Create test volume
-test_volume = np.random.rand(num_rows, num_cols, num_slices).astype(np.float32)
+test_volume = np.ones((num_rows, num_cols, num_slices)).astype(np.float32)
 print(f"Test volume: {test_volume.shape}, {test_volume.nbytes / (1024 ** 3):.3f} GB\n")
 
 # Output directory
@@ -37,14 +38,18 @@ print("=" * 70)
 # Test without slice_start and total_slices (full volume processing)
 print("\nTest 1: Full volume (slice_start=None, total_slices=None)")
 try:
+    import time
+    start_time = time.time()
     masked_full = mj.preprocess.apply_cylindrical_mask(
         test_volume,
         radial_margin=10,
         top_margin=10,
         bottom_margin=10
     )
+    masked_full = masked_full.block_until_ready()
+    elapsed_time = time.time() - start_time
     masked_full = jax.device_get(masked_full)
-    print("✓ Full volume processing completed successfully")
+    print("✓ Full volume processing completed successfully in {} seconds".format(elapsed_time))
     run_comparison = True
 except Exception as e:
     if "out of memory" in str(e).lower() or "RESOURCE_EXHAUSTED" in str(e):
@@ -58,7 +63,7 @@ except Exception as e:
         warnings.warn(f"Test 1 failed: {type(e).__name__}: {e}. Skipping comparison.", RuntimeWarning)
     run_comparison = False
 
-
+mj.slice_viewer(test_volume, masked_full)
 # Test with slice_start and total_slices (batch processing)
 print("\nTest 2: Batch processing with slice_start and total_slices")
 batch_result = np.zeros_like(test_volume)

--- a/experiments/preprocessing/export_recon_hdf5_test.py
+++ b/experiments/preprocessing/export_recon_hdf5_test.py
@@ -1,0 +1,167 @@
+"""
+Test script for export_recon_hdf5 and apply_cylindrical_mask functions.
+Tests the newly introduced parameters: batch_size, slice_start, and total_slices.
+"""
+
+import os
+import numpy as np
+import time
+import jax
+import mbirjax as mj
+import warnings
+
+# Volume shape parameters
+num_rows = 1024
+num_cols = 1024
+num_slices = 1024
+
+# Define batch size for testing apply_cylindrical_mask
+batch_size = 64
+
+# Create test volume
+test_volume = np.random.rand(num_rows, num_cols, num_slices).astype(np.float32)
+print(f"Test volume: {test_volume.shape}, {test_volume.nbytes / (1024 ** 3):.3f} GB\n")
+
+# Output directory
+output_path = '/home/yang1581/Data/test_export/'
+os.makedirs(output_path, exist_ok=True)
+
+# ============================================================================
+# Test apply_cylindrical_mask with slice_start and total_slices parameters
+# ============================================================================
+print("=" * 70)
+print("Testing apply_cylindrical_mask with slice_start and total_slices")
+print("=" * 70)
+
+
+# Test without slice_start and total_slices (full volume processing)
+print("\nTest 1: Full volume (slice_start=None, total_slices=None)")
+try:
+    masked_full = mj.preprocess.apply_cylindrical_mask(
+        test_volume,
+        radial_margin=10,
+        top_margin=10,
+        bottom_margin=10
+    )
+    masked_full = jax.device_get(masked_full)
+    print("✓ Full volume processing completed successfully")
+    run_comparison = True
+except Exception as e:
+    if "out of memory" in str(e).lower() or "RESOURCE_EXHAUSTED" in str(e):
+        warnings.warn(
+            f"GPU out of memory. To pass this test, use a smaller test volume. "
+            f"Current volume size: {test_volume.shape}, {test_volume.nbytes / (1024 ** 3):.3f} GB. "
+            f"Skipping full volume test and comparison.",
+            RuntimeWarning
+        )
+    else:
+        warnings.warn(f"Test 1 failed: {type(e).__name__}: {e}. Skipping comparison.", RuntimeWarning)
+    run_comparison = False
+
+
+# Test with slice_start and total_slices (batch processing)
+print("\nTest 2: Batch processing with slice_start and total_slices")
+batch_result = np.zeros_like(test_volume)
+batch_size = batch_size
+
+for start in range(0, num_slices, batch_size):
+    end = min(start + batch_size, num_slices)
+    batch = test_volume[:, :, start:end]
+
+    print(f"  Processing slices {start}-{end - 1} (slice_start={start}, total_slices={num_slices})")
+
+    masked_batch = mj.preprocess.apply_cylindrical_mask(
+        batch,
+        radial_margin=10,
+        top_margin=10,
+        bottom_margin=10,
+        slice_start=start,
+        total_slices=num_slices
+    )
+
+    batch_result[:, :, start:end] = masked_batch
+
+# Compare results
+if run_comparison:
+    max_diff = np.max(np.abs(masked_full - batch_result))
+    print(f"\nMax difference between full and batch: {max_diff}")
+    if max_diff < 1e-6:
+        print("✓ Batch processing matches full volume processing!\n")
+    else:
+        print("✗ WARNING: Batch processing does NOT match full volume processing!\n")
+else:
+    print("\n Comparison skipped (full volume test did not complete)\n")
+
+
+# Test error handling: only slice_start provided
+print("\nTest 3: Error handling - only slice_start provided (should raise ValueError)")
+try:
+    batch = test_volume[:, :, :batch_size]
+    masked_batch = mj.preprocess.apply_cylindrical_mask(
+        batch,
+        radial_margin=10,
+        top_margin=10,
+        bottom_margin=10,
+        slice_start=0,
+        total_slices=None
+    )
+    print("✗ ERROR: Should have raised ValueError but did not!\n")
+except ValueError as e:
+    print(f"✓ Correctly raised ValueError: {e}\n")
+except Exception as e:
+    print(f"✗ ERROR: Raised unexpected exception: {type(e).__name__}: {e}\n")
+
+
+# Test error handling: only total_slices provided
+print("\nTest 4: Error handling - only total_slices provided (should raise ValueError)")
+try:
+    batch = test_volume[:, :, :batch_size]
+    masked_batch = mj.preprocess.apply_cylindrical_mask(
+        batch,
+        radial_margin=10,
+        top_margin=10,
+        bottom_margin=10,
+        slice_start=None,
+        total_slices=num_slices
+    )
+    print("✗ ERROR: Should have raised ValueError but did not!\n")
+except ValueError as e:
+    print(f"✓ Correctly raised ValueError: {e}\n")
+except Exception as e:
+    print(f"✗ ERROR: Raised unexpected exception: {type(e).__name__}: {e}\n")
+
+
+# ============================================================================
+# Test export_recon_hdf5 with batch_size parameter
+# ============================================================================
+print("=" * 70)
+print("Testing export_recon_hdf5 with batch_size parameter")
+print("=" * 70)
+
+# Test cases with different batch_size values
+batch_sizes = [16, 32, 64, 128, 256, 512, 1024]
+
+print(f"\nRunning {len(batch_sizes)} test cases with different batch_size:\n")
+
+for i, batch_size in enumerate(batch_sizes, 1):
+    print(f"Test {i}/{len(batch_sizes)}: batch_size={batch_size}")
+
+    file_path = os.path.join(output_path, f"test_batch_{batch_size}.h5")
+
+    t0 = time.time()
+    mj.export_recon_hdf5(
+        file_path,
+        test_volume,
+        recon_dict=None,
+        remove_flash=True,
+        radial_margin=10,
+        top_margin=10,
+        bottom_margin=10,
+        batch_size=batch_size
+    )
+    t1 = time.time()
+    print(f"  Elapsed: {t1 - t0:.1f}s\n")
+
+print("=" * 70)
+print("All tests completed!")
+print("=" * 70)

--- a/mbirjax/preprocess/utilities.py
+++ b/mbirjax/preprocess/utilities.py
@@ -529,8 +529,8 @@ def project_vector_to_vector(u1, u2):
     return u1_proj
 
 from functools import partial
-@partial(jax.jit, static_argnames=['top_margin', 'bottom_margin', 'slice_start', 'total_slices'])
-def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0, slice_start=None, total_slices=None):
+@partial(jax.jit, static_argnames=['top_margin', 'bottom_margin'])
+def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0):
     """
     Applies a cylindrical mask to a 3D reconstruction volume.
 
@@ -540,23 +540,14 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
 
     This function is useful for removing `flash` that typically accumulates on the boundaries of an MBIR reconstruction volume.
 
-    The function can process either the entire reconstruction volume at once or process it in smaller
-    slice batches to manage memory constraints.
-
     Note:
-        When `slice_start` and `total_slices` are None, the function processes the entire recon volume.
-        When both are provided (batch mode), the function correctly applies top/bottom margins based on
-        the batch's position in the full recon volume, ensuring identical results to full-volume processing.
+        This function may need to be converted to batch over slices for very large recons.
 
     Args:
         recon (jnp.ndarray): 3D volume with shape (num_rows, num_cols, num_slices).
         radial_margin (int): Margin to subtract from the cylinder radius in pixels.
         top_margin (int): Number of top slices to set to zero along the Z-axis.
         bottom_margin (int): Number of bottom slices to set to zero along the Z-axis.
-        slice_start (int, optional): Starting slice index when processing batches.
-                                     If None, processes full recon volume (default behavior).
-        total_slices (int, optional): Total number of slices in full volume when batching.
-                                      If None, process full recon volume (default behavior).
 
     Returns:
         jnp.ndarray: Masked 3D volume of the same shape as `recon`.
@@ -590,33 +581,6 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
     if bottom_margin > 0:
         slice_mask = slice_mask.at[-bottom_margin:].set(0)
     recon = recon * slice_mask[None, None, :]
-
-    # # Zero out top and bottom slices along Z
-    # if slice_start is None and total_slices is None:
-    #     # Apply top/bottom margin to full recon volume
-    #     if top_margin > 0:
-    #         recon = recon.at[:, :, :top_margin].set(0)
-    #     if bottom_margin > 0:
-    #         recon = recon.at[:, :, -bottom_margin:].set(0)
-    # else:
-    #     # Validate that both batch parameters are provided
-    #     if slice_start is None or total_slices is None:
-    #         raise ValueError("Both slice_start and total_slices params must be provided together for batch processing.")
-    #
-    #     # Apply top/bottom margin to recon slice batches
-    #     slice_end = slice_start + num_slices
-    #
-    #     # Zero top slices only if this batch overlaps with top margin region in full recon volume
-    #     if top_margin > 0 and slice_start < top_margin:
-    #         top_margin_batch = min(top_margin - slice_start, num_slices)
-    #         recon = recon.at[:, :, :top_margin_batch].set(0)
-    #
-    #     # Zero bottom slices only if this batch overlaps with bottom margin region in full recon volume
-    #     if bottom_margin > 0:
-    #         bottom_start = total_slices - bottom_margin
-    #         if slice_end > bottom_start:
-    #             bottom_margin_batch = max(0, bottom_start - slice_start)
-    #             recon = recon.at[:, :, bottom_margin_batch:].set(0)
 
     return recon
 

--- a/mbirjax/preprocess/utilities.py
+++ b/mbirjax/preprocess/utilities.py
@@ -529,8 +529,8 @@ def project_vector_to_vector(u1, u2):
     return u1_proj
 
 from functools import partial
-@partial(jax.jit, static_argnames=['top_margin', 'bottom_margin'])
-def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0):
+@partial(jax.jit, static_argnames=['top_margin', 'bottom_margin', 'slice_start', 'total_slices'])
+def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0, slice_start=None, total_slices=None):
     """
     Applies a cylindrical mask to a 3D reconstruction volume.
 
@@ -540,11 +540,23 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
 
     This function is useful for removing `flash` that typically accumulates on the boundaries of an MBIR reconstruction volume.
 
+    The function can process either the entire reconstruction volume at once or process it in smaller
+    slice batches to manage memory constraints.
+
+    Note:
+        When `slice_start` and `total_slices` are None, the function processes the entire recon volume.
+        When both are provided (batch mode), the function correctly applies top/bottom margins based on
+        the batch's position in the full recon volume, ensuring identical results to full-volume processing.
+
     Args:
         recon (jnp.ndarray): 3D volume with shape (num_rows, num_cols, num_slices).
         radial_margin (int): Margin to subtract from the cylinder radius in pixels.
         top_margin (int): Number of top slices to set to zero along the Z-axis.
         bottom_margin (int): Number of bottom slices to set to zero along the Z-axis.
+        slice_start (int, optional): Starting slice index when processing batches.
+                                     If None, processes full recon volume (default behavior).
+        total_slices (int, optional): Total number of slices in full volume when batching.
+                                      If None, uses recon.shape[2] (default behavior).
 
     Returns:
         jnp.ndarray: Masked 3D volume of the same shape as `recon`.
@@ -572,10 +584,27 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
     recon = recon * circular_mask[:, :, None]
 
     # Zero out top and bottom slices along Z
-    if top_margin > 0:
-        recon = recon.at[:, :, :top_margin].set(0)
-    if bottom_margin > 0:
-        recon = recon.at[:, :, -bottom_margin:].set(0)
+    if slice_start is None and total_slices is None:
+        # Apply top/bottom margin to full recon volume
+        if top_margin > 0:
+            recon = recon.at[:, :, :top_margin].set(0)
+        if bottom_margin > 0:
+            recon = recon.at[:, :, -bottom_margin:].set(0)
+    else:
+        # Apply top/bottom margin to recon slice batches
+        slice_end = slice_start + num_slices
+
+        # Zero top slices only if this batch overlaps with top margin region in full recon volume
+        if top_margin > 0 and slice_start < top_margin:
+            top_margin_batch = min(top_margin - slice_start, num_slices)
+            recon = recon.at[:, :, :top_margin_batch].set(0)
+
+        # Zero bottom slices only if this batch overlaps with bottom margin region in full recon volume
+        if bottom_margin > 0:
+            bottom_start = total_slices - bottom_margin
+            if slice_end > bottom_start:
+                bottom_margin_batch = max(0, bottom_start - slice_start)
+                recon = recon.at[:, :, bottom_margin_batch:].set(0)
 
     return recon
 

--- a/mbirjax/preprocess/utilities.py
+++ b/mbirjax/preprocess/utilities.py
@@ -583,32 +583,40 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
     # Apply cylindrical mask to all slices
     recon = recon * circular_mask[:, :, None]
 
-    # Zero out top and bottom slices along Z
-    if slice_start is None and total_slices is None:
-        # Apply top/bottom margin to full recon volume
-        if top_margin > 0:
-            recon = recon.at[:, :, :top_margin].set(0)
-        if bottom_margin > 0:
-            recon = recon.at[:, :, -bottom_margin:].set(0)
-    else:
-        # Validate that both batch parameters are provided
-        if slice_start is None or total_slices is None:
-            raise ValueError("Both slice_start and total_slices params must be provided together for batch processing.")
+    # Apply a mask to the top and bottom margins
+    slice_mask = jnp.ones((num_slices, ))
+    if top_margin > 0:
+        slice_mask = slice_mask.at[:top_margin].set(0)
+    if bottom_margin > 0:
+        slice_mask = slice_mask.at[-bottom_margin:].set(0)
+    recon = recon * slice_mask[None, None, :]
 
-        # Apply top/bottom margin to recon slice batches
-        slice_end = slice_start + num_slices
-
-        # Zero top slices only if this batch overlaps with top margin region in full recon volume
-        if top_margin > 0 and slice_start < top_margin:
-            top_margin_batch = min(top_margin - slice_start, num_slices)
-            recon = recon.at[:, :, :top_margin_batch].set(0)
-
-        # Zero bottom slices only if this batch overlaps with bottom margin region in full recon volume
-        if bottom_margin > 0:
-            bottom_start = total_slices - bottom_margin
-            if slice_end > bottom_start:
-                bottom_margin_batch = max(0, bottom_start - slice_start)
-                recon = recon.at[:, :, bottom_margin_batch:].set(0)
+    # # Zero out top and bottom slices along Z
+    # if slice_start is None and total_slices is None:
+    #     # Apply top/bottom margin to full recon volume
+    #     if top_margin > 0:
+    #         recon = recon.at[:, :, :top_margin].set(0)
+    #     if bottom_margin > 0:
+    #         recon = recon.at[:, :, -bottom_margin:].set(0)
+    # else:
+    #     # Validate that both batch parameters are provided
+    #     if slice_start is None or total_slices is None:
+    #         raise ValueError("Both slice_start and total_slices params must be provided together for batch processing.")
+    #
+    #     # Apply top/bottom margin to recon slice batches
+    #     slice_end = slice_start + num_slices
+    #
+    #     # Zero top slices only if this batch overlaps with top margin region in full recon volume
+    #     if top_margin > 0 and slice_start < top_margin:
+    #         top_margin_batch = min(top_margin - slice_start, num_slices)
+    #         recon = recon.at[:, :, :top_margin_batch].set(0)
+    #
+    #     # Zero bottom slices only if this batch overlaps with bottom margin region in full recon volume
+    #     if bottom_margin > 0:
+    #         bottom_start = total_slices - bottom_margin
+    #         if slice_end > bottom_start:
+    #             bottom_margin_batch = max(0, bottom_start - slice_start)
+    #             recon = recon.at[:, :, bottom_margin_batch:].set(0)
 
     return recon
 

--- a/mbirjax/preprocess/utilities.py
+++ b/mbirjax/preprocess/utilities.py
@@ -556,7 +556,7 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
         slice_start (int, optional): Starting slice index when processing batches.
                                      If None, processes full recon volume (default behavior).
         total_slices (int, optional): Total number of slices in full volume when batching.
-                                      If None, uses recon.shape[2] (default behavior).
+                                      If None, process full recon volume (default behavior).
 
     Returns:
         jnp.ndarray: Masked 3D volume of the same shape as `recon`.
@@ -591,6 +591,10 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
         if bottom_margin > 0:
             recon = recon.at[:, :, -bottom_margin:].set(0)
     else:
+        # Validate that both batch parameters are provided
+        if slice_start is None or total_slices is None:
+            raise ValueError("Both slice_start and total_slices params must be provided together for batch processing.")
+
         # Apply top/bottom margin to recon slice batches
         slice_end = slice_start + num_slices
 

--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -550,13 +550,14 @@ def get_top_level_tar_dir(tar_path, max_entries=1):
 
 
 
-def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, radial_margin=10, top_margin=10, bottom_margin=10):
+def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, radial_margin=10, top_margin=10, bottom_margin=10, batch_size=1024):
     """
     Export a 3D reconstruction volume to an HDF5 file with optional post-processing.
 
-    This function transposes the input volume to right-hand coordinates (slice, row, col),
-    optionally applies a cylindrical mask to remove peripheral and top/bottom slices (referred to as `flash`),
-    and writes the volume and optional metadata to an HDF5 file.
+    This function processes the input recon volume in batches to avoid GPU memory issues, transposes it
+    to right-hand coordinates (slice, col, row), optionally applies a cylindrical mask to remove
+    peripheral and top/bottom slices (referred to as `flash`), and writes the volume and optional
+    metadata to an HDF5 file.
 
     Args:
         file_path (str): Full path to the output HDF5 file. Parent directories will be created if they do not exist.
@@ -566,6 +567,7 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, rad
         radial_margin (int, optional): Margin in pixels to subtract from the cylinder radius. Defaults to 10.
         top_margin (int, optional): Number of top slices to set to zero along the Z-axis. Defaults to 10.
         bottom_margin (int, optional): Number of bottom slices to set to zero along the Z-axis. Defaults to 10.
+        batch_size (int, optional): Number of slices to process at a time. Defaults to 1024.
 
     Example:
         >>> from mbirjax.utilities import export_recon_hdf5
@@ -574,19 +576,33 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, rad
         >>> export_recon_hdf5("output/recon_volume.h5", recon, recon_dict={"scan_id": "sample1"})
     """
 
-    @jax.jit
-    def process_recon(local_recon):
+    # Move recon to CPU
+    recon = jax.device_get(recon)
+
+    # Process recon in batches
+    num_rows, num_cols, num_slices = recon.shape
+
+    output = np.zeros((num_slices, num_cols, num_rows), dtype=recon.dtype)
+
+    # Process recon slices in batches to manage GPU memory
+    for start in range(0, num_slices, batch_size):
+        end = min(start + batch_size, num_slices)
+
+        batch = jax.device_put(recon[:, :, start:end])
 
         if remove_flash:
-            local_recon = mj.preprocess.apply_cylindrical_mask(local_recon, radial_margin, top_margin, bottom_margin)
+            batch = mj.preprocess.apply_cylindrical_mask(batch, radial_margin, top_margin, bottom_margin, start, num_slices)
 
-        # Convert to right-handed coordinate system
-        local_recon = jnp.transpose(local_recon, (2, 1, 0))
-        local_recon = jax.device_get(local_recon)
-        return local_recon
+        # Convert the batch to right-handed coordinate system
+        batch = jnp.transpose(batch, (2, 1, 0))
 
-    recon = jax.device_get(recon)
-    recon = process_recon(recon)
+        # Move back to CPU and store
+        output[start:end, :, :] = jax.device_get(batch)
+
+        # Clear GPU memory
+        jax.clear_caches()
+
+    recon = output
     save_data_hdf5(file_path, recon, 'recon', recon_dict)
 
 

--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -550,7 +550,7 @@ def get_top_level_tar_dir(tar_path, max_entries=1):
 
 
 
-def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, radial_margin=10, top_margin=10, bottom_margin=10, batch_size=1024):
+def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, radial_margin=10, top_margin=10, bottom_margin=10):
     """
     Export a 3D reconstruction volume to an HDF5 file with optional post-processing.
 
@@ -567,7 +567,6 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, rad
         radial_margin (int, optional): Margin in pixels to subtract from the cylinder radius. Defaults to 10.
         top_margin (int, optional): Number of top slices to set to zero along the Z-axis. Defaults to 10.
         bottom_margin (int, optional): Number of bottom slices to set to zero along the Z-axis. Defaults to 10.
-        batch_size (int, optional): Number of slices to process at a time. Defaults to 1024.
 
     Example:
         >>> from mbirjax.utilities import export_recon_hdf5
@@ -576,33 +575,15 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, rad
         >>> export_recon_hdf5("output/recon_volume.h5", recon, recon_dict={"scan_id": "sample1"})
     """
 
-    if batch_size <= 0:
-        raise ValueError(f"batch_size must be a positive integer, got {batch_size}.")
 
     # Move recon to CPU
     recon = jax.device_get(recon)
 
-    # Process recon in batches
-    num_rows, num_cols, num_slices = recon.shape
+    if remove_flash:
+        recon = mj.preprocess.apply_cylindrical_mask(recon, radial_margin, top_margin, bottom_margin)
 
-    output = np.zeros((num_slices, num_cols, num_rows), dtype=recon.dtype)
+    recon = jnp.transpose(recon, (2, 1, 0))
 
-    # Process recon slices in batches to manage GPU memory
-    for start in range(0, num_slices, batch_size):
-        end = min(start + batch_size, num_slices)
-
-        batch = jax.device_put(recon[:, :, start:end])
-
-        if remove_flash:
-            batch = mj.preprocess.apply_cylindrical_mask(batch, radial_margin, top_margin, bottom_margin, start, num_slices)
-
-        # Convert the batch to right-handed coordinate system
-        batch = jnp.transpose(batch, (2, 1, 0))
-
-        # Move back to CPU and store
-        output[start:end, :, :] = jax.device_get(batch)
-
-    recon = output
     save_data_hdf5(file_path, recon, 'recon', recon_dict)
 
 
@@ -631,7 +612,7 @@ def import_recon_hdf5(file_path):
     recon, recon_dict = load_data_hdf5(file_path=file_path)
 
     recon = recon[::-1, :, :]
-    recon = np.transpose(recon, axes=(1, 2, 0))
+    recon = np.transpose(recon, axes=(2, 1, 0))
 
     return recon, recon_dict
 

--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -576,6 +576,9 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, rad
         >>> export_recon_hdf5("output/recon_volume.h5", recon, recon_dict={"scan_id": "sample1"})
     """
 
+    if batch_size <= 0:
+        raise ValueError(f"batch_size must be a positive integer, got {batch_size}.")
+
     # Move recon to CPU
     recon = jax.device_get(recon)
 
@@ -598,9 +601,6 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, rad
 
         # Move back to CPU and store
         output[start:end, :, :] = jax.device_get(batch)
-
-        # Clear GPU memory
-        jax.clear_caches()
 
     recon = output
     save_data_hdf5(file_path, recon, 'recon', recon_dict)


### PR DESCRIPTION
This PR modified export_recon_hdf5 and apply_cylindrical_mask function to process recon in slices batches, preventing GPU out-of-memory errors when saving very large reconstructions

To test the code, run any experiment scripts in experiments/zeiss folder and then use mj.load_data_hdf5 to read the saved file.