### PR TITLE
Fix bug in translation_model.py and zeiss_tct.py

### DIFF
--- a/mbirjax/preprocess/zeiss_tct.py
+++ b/mbirjax/preprocess/zeiss_tct.py
@@ -127,11 +127,11 @@ def load_scans_and_params(dataset_dir, verbose=1):
     _, Zeiss_params = read_xrm_dir(obj_scan_dir) # Zeiss parameters of all the object scans
 
     # source to iso distance
-    source_iso_dist = Zeiss_params["source_iso_dist"]
+    source_iso_dist = Zeiss_params["source_iso_dist"][0]
     source_iso_dist = float(np.abs(source_iso_dist))
 
     # iso to detector distance
-    iso_det_dist = Zeiss_params["iso_det_dist"]
+    iso_det_dist = Zeiss_params["iso_det_dist"][0]
     iso_det_dist = float(np.abs(iso_det_dist))
 
     # detector pixel pitch

--- a/mbirjax/translation_model.py
+++ b/mbirjax/translation_model.py
@@ -65,10 +65,10 @@ class TranslationModel(mj.TomographyModel):
         translation_vectors = jnp.asarray(translation_vectors)
         view_params_name = 'translation_vectors'
 
-        self.max_over_relaxation = 1.0  # We override this value due to observed instabilities with larger values
-
         super().__init__(sinogram_shape, translation_vectors=translation_vectors, source_detector_dist=source_detector_dist,
                          source_iso_dist=source_iso_dist, view_params_name=view_params_name, qggmrf_nbr_wts=(0.1, 1, 1,))
+
+        self.max_over_relaxation = 1.0  # We override this value due to observed instabilities with larger values
 
     def get_magnification(self):
         """


### PR DESCRIPTION
This PR fixes the following two bugs:

1. Ensure self.max_over_relaxation is correctly overridden in translation_model.py

2. Correctly convert source_iso_dist and iso_det_dist to scalars in zeiss_tct.py


To test the PR, please run TCT_physical_experiment.py in mbirjax/experiments/translation/ folder