### PR TITLE
Avoid unintended GPU allocation in recon initialization

### DIFF
--- a/mbirjax/tomography_model.py
+++ b/mbirjax/tomography_model.py
@@ -566,7 +566,8 @@ class TomographyModel(ParameterHandler):
         output_device = self.main_device
         recon_cylinder = self.sparse_back_project(sinogram, full_indices, output_device=output_device)
         row_index, col_index = jnp.unravel_index(full_indices, recon_shape[:2])
-        recon = jnp.zeros(recon_shape, device=output_device)
+        with jax.default_device(output_device):
+            recon = jnp.zeros(recon_shape, device=output_device)
         recon = recon.at[row_index, col_index].set(recon_cylinder)
         return recon
 


### PR DESCRIPTION
This PR addresses a GPU out-of-memory issue observed when creating empty array for FDK with
jnp.zeros(recon_shape, device=cpu).

Although the array is intended to be created on CPU, in practice this line of code still triggers GPU memory allocation and can result in an OOM.

After modification, this error is not triggered.

We should also further investigate GPU memory usage and tracing through the full recon pipeline.