### PR TITLE
Updated transmission mode and function parameters

### DIFF
--- a/experiments/hsnt/example_1_denoise_simulated_data.py
+++ b/experiments/hsnt/example_1_denoise_simulated_data.py
@@ -26,7 +26,7 @@ def main():
     dataset_type = 'attenuation'  # Choose between 'attenuation' or 'transmission'
 
     # Denoiser parameters
-    subspace_dimension = None  # Subspace dimension
+    num_materials = None  # Number of materials
     verbose = 2  # Verbosity level
 
     # Display parameters
@@ -56,7 +56,7 @@ def main():
     # Perform hyperspectral denoising (dehydrate + rehydrate)
     denoised_hyper_projection = hyper_denoise(noisy_hyper_projection,
                                               dataset_type=dataset_type,
-                                              subspace_dimension=subspace_dimension,
+                                              num_materials=num_materials,
                                               verbose=verbose)
 
     # Plot hyperspectral projections and spectra

--- a/experiments/hsnt/example_2_denoise_real_data.py
+++ b/experiments/hsnt/example_2_denoise_real_data.py
@@ -25,7 +25,7 @@ def main():
     os.makedirs(output_path, exist_ok=True)  # Make output directory if it does not exist
 
     # Denoiser parameters
-    subspace_dimension = None  # Subspace dimension
+    num_materials = None  # Number of materials
     verbose = 2  # Verbosity level
     test_denoise = False  # If True, test hyper_denoise; if False, test dehydrate + rehydrate sequence
 
@@ -52,11 +52,11 @@ def main():
     if test_denoise:
         if verbose >= 1:
             print("Running hyperspectral denoising (i.e., dehydrate + rehydrate)")
-        hsnt_denoised = hyper_denoise(hsnt_data, dataset_type=dataset_type, subspace_dimension=subspace_dimension, verbose=verbose)
+        hsnt_denoised = hyper_denoise(hsnt_data, dataset_type=dataset_type, num_materials=num_materials, verbose=verbose)
     else:
         if verbose >= 1:
             print("Running hyperspectral dehydrate followed by rehydrate (i.e., denoising)")
-        hsnt_dehydrated = dehydrate(hsnt_data, dataset_type=dataset_type, subspace_dimension=subspace_dimension, verbose=verbose)
+        hsnt_dehydrated = dehydrate(hsnt_data, dataset_type=dataset_type, num_materials=num_materials, verbose=verbose)
         hsnt_denoised = rehydrate(hsnt_dehydrated)
 
         # Write out dehydrated data

--- a/experiments/hsnt/mini_example_transmission.py
+++ b/experiments/hsnt/mini_example_transmission.py
@@ -1,0 +1,62 @@
+"""
+Hyperspectral Dehydration & Rehydration
+---------------------------------------
+
+This mini script tests the performance of the algorithm for low quality transmission data.
+"""
+
+import time
+import numpy as np
+import matplotlib.pyplot as plt
+from mbirjax.hsnt import hyper_denoise
+
+
+def main():
+    start_time = time.time()
+
+    # Parameters
+    num_materials = 1
+    max_iter=300
+
+    # Load noisy transmission data and corresponding wavelength values
+    noisy_data = np.load("./input_data/test_transmission_data_0.8C.npy")
+    wavelengths = np.load("./input_data/test_wavelengths_0.8C.npy")
+
+    # Denoise using wrong (attenuation) and right (transmission) mode
+    denoised_data_a = hyper_denoise(noisy_data, dataset_type='attenuation', num_materials=num_materials, max_iter=max_iter)
+    denoised_data_b = hyper_denoise(noisy_data, dataset_type='transmission', num_materials=num_materials, max_iter=max_iter)
+
+
+    # Plot attenuation mode results
+    plt.figure()
+    plt.plot(wavelengths, noisy_data[200,200], '.', color='gray', markersize = 1, label = 'raw pixel')
+    plt.plot(wavelengths, denoised_data_a[200,200], '.', color='navy', markersize = 1, label = 'denoised pixel')
+    plt.plot(wavelengths, np.mean(noisy_data[160:350,160:350], axis=(0,1)), '.', color='red', markersize = 1, 
+             label = 'raw avg over pixels')
+    plt.plot(wavelengths, np.mean(denoised_data_a[160:350,160:350], axis=(0,1)), '.', color='green', markersize = 1, 
+             label = 'denoised avg over pixels')
+    plt.ylim(-0.5,1.05)
+    plt.grid(linestyle='--')
+    plt.legend(markerscale=10, loc='best', ncol=2)
+    plt.title(f'Pixel Spectra at (200,200) using "attenuation"', fontweight='bold', fontsize=12, y=1.02)
+
+    # Plot transmission mode results
+    plt.figure()
+    plt.plot(wavelengths, noisy_data[200,200], '.', color='gray', markersize = 1, label = 'raw pixel')
+    plt.plot(wavelengths, denoised_data_b[200,200], '.', color='navy', markersize = 1, label = 'denoised pixel')
+    plt.plot(wavelengths, np.mean(noisy_data[160:350,160:350], axis=(0,1)), '.', color='red', markersize = 1, 
+             label = 'raw avg over pixels')
+    plt.plot(wavelengths, np.mean(denoised_data_b[160:350,160:350], axis=(0,1)), '.', color='green', markersize = 1, 
+             label = 'denoised avg over pixels')
+    plt.ylim(-0.5,1.05)
+    plt.grid(linestyle='--')
+    plt.legend(markerscale=10, loc='best', ncol=2)
+    plt.title(f'Pixel Spectra at (200,200) using "transmission"', fontweight='bold', fontsize=12, y=1.02)
+
+    print('Total time elapsed: ', time.time() - start_time, ' seconds')
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/mbirjax/hsnt.py
+++ b/mbirjax/hsnt.py
@@ -12,8 +12,8 @@ from sklearn.utils.extmath import randomized_svd
 # -----------------------------------------------------------------------
 
 
-def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, subspace_basis=None, safety_factor=2,
-                  batch_size=2 ** 27, beta_loss='frobenius', max_iter=300, tolerance=1e-10, verbose=1):
+def hyper_denoise(data, dataset_type='attenuation', num_materials=None, safety_factor=2, beta_loss='frobenius', 
+                  max_iter=300, tolerance=1e-10, batch_size=2 ** 27, subspace_basis=None, verbose=1):
     """
     Denoise a hyperspectral dataset using dehydration and rehydration.
 
@@ -28,16 +28,15 @@ def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, sub
     Args:
         data: Hyperspectral data array with arbitrary axes and a spectral axis of length :math:`N_k` in the last position.
         dataset_type: 'attenuation' or 'transmission' where attenuation = -log(transmission). Defaults to 'attenuation'.
-        subspace_dimension: Desired dimension of the subspace :math:`N_s`. If None, the dimension is either set from the
-            provided subspace basis matrix or estimated automatically from the data. Defaults to None.
-        subspace_basis: Pre-computed subspace basis spectra of shape :math:`(N_s, N_k)`. If None, the basis spectra are
-            estimated directly from the data. Defaults to None.
-        safety_factor: Multiplicative factor ≥ 1 used to scale the initial estimate of subspace dimension and ensure
-            safer final choice. Defaults to 2.
-        batch_size: Size of data processed per batch. Useful for large datasets to limit memory usage. Defaults to 2**24.
+        num_materials: Number of materials in the sample :math:`N_m`. If None, the number is estimated automatically from 
+            the data. Defaults to None.
+safety_factor: A multiplier (≥ 1) applied to the number of materials to set the subspace dimension :math:`N_s`. Defaults to 2.
         beta_loss: Beta divergence minimized in NMF. Can be 'frobenius' or 'kullback-leibler'. Defaults to 'frobenius'.
         max_iter: Maximum iterations for the NMF solver. Defaults to 300.
         tolerance: Convergence tolerance for the NMF solver. Defaults to 1e-10.
+        batch_size: Size of data processed per batch. Useful for large datasets to limit memory usage. Defaults to 2^27.
+        subspace_basis: Pre-computed subspace basis spectra of shape :math:`(N_s, N_k)`. If None, the basis spectra are
+            estimated directly from the data. Defaults to None.
         verbose: Verbosity level. If 0, prints nothing; if 1, prints details; if >1, also generates plots. Defaults to 1.
 
     Returns:
@@ -60,13 +59,13 @@ def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, sub
     # --------------------- Dehydrate ----------------------
     dehydrated_data = dehydrate(data,
                                 dataset_type=dataset_type,
-                                subspace_dimension=subspace_dimension,
-                                subspace_basis=subspace_basis,
+                                num_materials=num_materials,
                                 safety_factor=safety_factor,
-                                batch_size=batch_size,
                                 beta_loss=beta_loss,
                                 max_iter=max_iter,
                                 tolerance=tolerance,
+                                batch_size=batch_size,
+                                subspace_basis=subspace_basis,
                                 verbose=verbose)
 
     # --------------------- Rehydrate ----------------------
@@ -75,8 +74,8 @@ def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, sub
     return denoised_data
 
 
-def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspace_basis=None, safety_factor=2,
-              batch_size=2 ** 27, beta_loss='frobenius', max_iter=300, tolerance=1e-10, verbose=1):
+def dehydrate(data, dataset_type='attenuation', num_materials=None, safety_factor=2, beta_loss='frobenius', 
+              max_iter=300, tolerance=1e-10, batch_size=2 ** 27, subspace_basis=None, verbose=1):
     """
     Dehydrate/compress a hyperspectral dataset onto a low-dimensional subspace.
 
@@ -87,16 +86,15 @@ def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspac
     Args:
         data: Hyperspectral data array with arbitrary axes and a spectral axis of length :math:`N_k` in the last position.
         dataset_type: 'attenuation' or 'transmission' where attenuation = -log(transmission). Defaults to 'attenuation'.
-        subspace_dimension: Desired dimension of the subspace :math:`N_s`. If None, the dimension is either set from the
-            provided subspace basis matrix or estimated automatically from the data. Defaults to None.
-        subspace_basis: Pre-computed subspace basis spectra of shape :math:`(N_s, N_k)`. If None, the basis spectra are
-            estimated directly from the data. Defaults to None.
-        safety_factor: Multiplicative factor ≥ 1 used to scale the initial estimate of subspace dimension and ensure
-            safer final choice. Defaults to 2.
-        batch_size: Size of data processed per batch. Useful for large datasets to limit memory usage. Defaults to 2**24.
+        num_materials: Number of materials in the sample :math:`N_m`. If None, the number is estimated automatically from 
+            the data. Defaults to None.
+        safety_factor: A multiplier (≥ 1) applied to the number of materials to set the subspace dimension :math:`N_s`. Defaults to 2.
         beta_loss: Beta divergence minimized in NMF. Can be 'frobenius' or 'kullback-leibler'. Defaults to 'frobenius'.
         max_iter: Maximum iterations for the NMF solver. Defaults to 300.
         tolerance: Convergence tolerance for the NMF solver. Defaults to 1e-10.
+        batch_size: Size of data processed per batch. Useful for large datasets to limit memory usage. Defaults to 2^27.
+        subspace_basis: Pre-computed subspace basis spectra of shape :math:`(N_s, N_k)`. If None, the basis spectra are
+            estimated directly from the data. Defaults to None.
         verbose: Verbosity level. If 0, prints nothing; if 1, prints details; if >1, also generates plots. Defaults to 1.
 
     Returns:
@@ -135,12 +133,12 @@ def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspac
         # Initial cleanup in the transmission domain to get rid of defective measurements
         data = hyper_denoise(data,
                              dataset_type='attenuation',
-                             subspace_dimension=(subspace_dimension * 3 if subspace_dimension is not None else None),
+                             num_materials=num_materials,
                              safety_factor=safety_factor * 3,
-                             batch_size=batch_size,
                              beta_loss=beta_loss,
                              max_iter=max_iter,
                              tolerance=tolerance,
+                             batch_size=batch_size,
                              verbose=0)
         data[data < epsilon] = epsilon
         data = - np.log(data)  # Convert to attenuation
@@ -165,10 +163,12 @@ def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspac
         solver = 'cd'
 
     # ------------- Subspace dimension setup -----------------
-    if subspace_dimension is None and subspace_basis is None:
-        subspace_dimension = _estimate_subspace_dimension(data, safety_factor=safety_factor, verbose=verbose)
-    elif subspace_dimension is None and subspace_basis is not None:
+    if subspace_basis is not None:
         subspace_dimension = subspace_basis.shape[0]
+    elif num_materials is not None:
+        subspace_dimension = int(np.ceil(safety_factor * num_materials))
+    else:
+        subspace_dimension = _estimate_subspace_dimension(data, safety_factor=safety_factor, verbose=verbose)
 
     # ------- Subspace basis estimation for multi-batch ------
     if subspace_basis is None and num_batches > 1:
@@ -250,7 +250,7 @@ def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspac
         print("dehydrate(): ")
         print("   -Number of data batches: ", num_batches)
         print("   -Original spectral dimension: ", data.shape[-1])
-        print("   -Estimated/given subspace dimension: ", subspace_data.shape[-1])
+        print("   -Subspace dimension: ", subspace_data.shape[-1])
 
     return dehydrated_data
 
@@ -363,20 +363,20 @@ def _estimate_subspace_dimension(data, safety_factor=2, noise_fit_window=[25.0, 
 
     # Consider singular values > the corresponding tau values to be associated with signals
     signal_flag = s > tau
-    subspace_dimension = int(np.sum(signal_flag[:start_idx]))
+    num_materials = int(np.sum(signal_flag[:start_idx]))
 
     if verbose > 1:
         plt.figure()
         plt.semilogy(s, label='s: actual singular values from data (signal + noise)')
         plt.semilogy(s_pred, label='s_pred: predicted singular values from noise model')
         plt.semilogy(tau, label='tau: noise and signal discriminator (threshold x s_pred)')
-        plt.title("Modeling noise singular values for subspace dimension estimation")
+        plt.title("Modeling noise singular values for number of material estimation")
         plt.xlabel("singular value index")
         plt.ylabel("singular value")
         plt.legend()
 
     # Multiply by safety factor
-    subspace_dimension = int(np.ceil(safety_factor * subspace_dimension))
+    subspace_dimension = int(np.ceil(safety_factor * num_materials))
 
     return max(1, subspace_dimension)
 

--- a/mbirjax/hsnt.py
+++ b/mbirjax/hsnt.py
@@ -43,7 +43,7 @@ safety_factor: A multiplier (≥ 1) applied to the number of materials to set th
         Denoised hyperspectral data with the same shape as the input data.
 
     Example:
-        >>> denoised_data = hyper_denoise(data, subspace_dimension=10)
+        >>> denoised_data = hyper_denoise(data, num_materials=10)
         >>> data.shape, denoised_data.shape
         ((N_x, N_y, N_z, ..., N_k), (N_x, N_y, N_z, ..., N_k))
 
@@ -104,7 +104,7 @@ def dehydrate(data, dataset_type='attenuation', num_materials=None, safety_facto
             - dataset_type: Can be 'attenuation' or 'transmission' where attenuation = -log(transmission).
 
     Example:
-        >>> [subspace_data, subspace_basis, dataset_type] = dehydrate(data, subspace_dimension=10)
+        >>> [subspace_data, subspace_basis, dataset_type] = dehydrate(data, num_materials=10)
         >>> data.shape, subspace_data.shape, subspace_basis.shape
         ((N_x, N_y, N_z, ..., N_k), (N_x, N_y, N_z, ..., 10), (10, N_k))
 

--- a/mbirjax/hsnt.py
+++ b/mbirjax/hsnt.py
@@ -30,7 +30,8 @@ def hyper_denoise(data, dataset_type='attenuation', num_materials=None, safety_f
         dataset_type: 'attenuation' or 'transmission' where attenuation = -log(transmission). Defaults to 'attenuation'.
         num_materials: Number of materials in the sample :math:`N_m`. If None, the number is estimated automatically from 
             the data. Defaults to None.
-safety_factor: A multiplier (≥ 1) applied to the number of materials to set the subspace dimension :math:`N_s`. Defaults to 2.
+        safety_factor: A multiplier (≥ 1) applied to the number of materials to set the subspace dimension :math:`N_s`.
+            Defaults to 2.
         beta_loss: Beta divergence minimized in NMF. Can be 'frobenius' or 'kullback-leibler'. Defaults to 'frobenius'.
         max_iter: Maximum iterations for the NMF solver. Defaults to 300.
         tolerance: Convergence tolerance for the NMF solver. Defaults to 1e-10.
@@ -43,7 +44,7 @@ safety_factor: A multiplier (≥ 1) applied to the number of materials to set th
         Denoised hyperspectral data with the same shape as the input data.
 
     Example:
-        >>> denoised_data = hyper_denoise(data, num_materials=10)
+        >>> denoised_data = hyper_denoise(data, num_materials=5, safety_factor=2)
         >>> data.shape, denoised_data.shape
         ((N_x, N_y, N_z, ..., N_k), (N_x, N_y, N_z, ..., N_k))
 
@@ -88,7 +89,8 @@ def dehydrate(data, dataset_type='attenuation', num_materials=None, safety_facto
         dataset_type: 'attenuation' or 'transmission' where attenuation = -log(transmission). Defaults to 'attenuation'.
         num_materials: Number of materials in the sample :math:`N_m`. If None, the number is estimated automatically from 
             the data. Defaults to None.
-        safety_factor: A multiplier (≥ 1) applied to the number of materials to set the subspace dimension :math:`N_s`. Defaults to 2.
+        safety_factor: A multiplier (≥ 1) applied to the number of materials to set the subspace dimension :math:`N_s`.
+            Defaults to 2.
         beta_loss: Beta divergence minimized in NMF. Can be 'frobenius' or 'kullback-leibler'. Defaults to 'frobenius'.
         max_iter: Maximum iterations for the NMF solver. Defaults to 300.
         tolerance: Convergence tolerance for the NMF solver. Defaults to 1e-10.
@@ -104,7 +106,7 @@ def dehydrate(data, dataset_type='attenuation', num_materials=None, safety_facto
             - dataset_type: Can be 'attenuation' or 'transmission' where attenuation = -log(transmission).
 
     Example:
-        >>> [subspace_data, subspace_basis, dataset_type] = dehydrate(data, num_materials=10)
+        >>> [subspace_data, subspace_basis, dataset_type] = dehydrate(data, num_materials=5, safety_factor=2)
         >>> data.shape, subspace_data.shape, subspace_basis.shape
         ((N_x, N_y, N_z, ..., N_k), (N_x, N_y, N_z, ..., 10), (10, N_k))
 

--- a/mbirjax/hsnt.py
+++ b/mbirjax/hsnt.py
@@ -13,7 +13,7 @@ from sklearn.utils.extmath import randomized_svd
 
 
 def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, subspace_basis=None, safety_factor=2,
-                  batch_size=2 ** 27, beta_loss='frobenius', max_iter=300, tolerance=1e-6, verbose=1):
+                  batch_size=2 ** 27, beta_loss='frobenius', max_iter=300, tolerance=1e-10, verbose=1):
     """
     Denoise a hyperspectral dataset using dehydration and rehydration.
 
@@ -37,7 +37,7 @@ def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, sub
         batch_size: Size of data processed per batch. Useful for large datasets to limit memory usage. Defaults to 2**24.
         beta_loss: Beta divergence minimized in NMF. Can be 'frobenius' or 'kullback-leibler'. Defaults to 'frobenius'.
         max_iter: Maximum iterations for the NMF solver. Defaults to 300.
-        tolerance: Convergence tolerance for the NMF solver. Defaults to 1e-6.
+        tolerance: Convergence tolerance for the NMF solver. Defaults to 1e-10.
         verbose: Verbosity level. If 0, prints nothing; if 1, prints details; if >1, also generates plots. Defaults to 1.
 
     Returns:
@@ -76,7 +76,7 @@ def hyper_denoise(data, dataset_type='attenuation', subspace_dimension=None, sub
 
 
 def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspace_basis=None, safety_factor=2,
-              batch_size=2 ** 27, beta_loss='frobenius', max_iter=300, tolerance=1e-6, verbose=1):
+              batch_size=2 ** 27, beta_loss='frobenius', max_iter=300, tolerance=1e-10, verbose=1):
     """
     Dehydrate/compress a hyperspectral dataset onto a low-dimensional subspace.
 
@@ -96,7 +96,7 @@ def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspac
         batch_size: Size of data processed per batch. Useful for large datasets to limit memory usage. Defaults to 2**24.
         beta_loss: Beta divergence minimized in NMF. Can be 'frobenius' or 'kullback-leibler'. Defaults to 'frobenius'.
         max_iter: Maximum iterations for the NMF solver. Defaults to 300.
-        tolerance: Convergence tolerance for the NMF solver. Defaults to 1e-6.
+        tolerance: Convergence tolerance for the NMF solver. Defaults to 1e-10.
         verbose: Verbosity level. If 0, prints nothing; if 1, prints details; if >1, also generates plots. Defaults to 1.
 
     Returns:
@@ -119,7 +119,7 @@ def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspac
             IEEE Transactions on Computational Imaging, vol. 11, pp. 663–677,
             2025. doi:10.1109/TCI.2025.3567854
     """
-    epsilon = 1e-8  # Define epsilon
+    epsilon = 1e-3  # Define epsilon
 
     # --------------- Dataset type validation --------------
     if dataset_type not in ('attenuation', 'transmission'):
@@ -132,6 +132,16 @@ def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspac
     data = data.reshape(num_points, num_bands).astype(np.float64)  # Reshape to 2D and cast to float64 for stability
 
     if dataset_type == 'transmission':
+        # Initial cleanup in the transmission domain to get rid of defective measurements
+        data = hyper_denoise(data,
+                             dataset_type='attenuation',
+                             subspace_dimension=(subspace_dimension * 3 if subspace_dimension is not None else None),
+                             safety_factor=safety_factor * 3,
+                             batch_size=batch_size,
+                             beta_loss=beta_loss,
+                             max_iter=max_iter,
+                             tolerance=tolerance,
+                             verbose=0)
         data[data < epsilon] = epsilon
         data = - np.log(data)  # Convert to attenuation
 
@@ -177,8 +187,8 @@ def dehydrate(data, dataset_type='attenuation', subspace_dimension=None, subspac
                 subspace_data_init = None
             else:
                 nmf_init = 'custom'  # Initialize NMF based on subspace basis from the previous batch
-                subspace_basis_init = gaussian_filter1d(subspace_basis_batch[batch-1], sigma=10, axis=1)
-                subspace_data_init = abs(batch_data @ np.linalg.pinv(subspace_basis_init))
+                subspace_basis_init = gaussian_filter1d(subspace_basis_batch[batch-1], sigma=10, axis=1) + epsilon
+                subspace_data_init = abs(batch_data @ np.linalg.pinv(subspace_basis_init)) + epsilon
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")

--- a/tests/test_hsnt.py
+++ b/tests/test_hsnt.py
@@ -21,7 +21,10 @@ class TestHSNT(unittest.TestCase):
         self.detector_rows = 16
         self.detector_columns = 16
         self.wavelengths = 10  # N_k
-        self.subspace_dim = 2  # N_s
+        self.num_materials = 2  # N_m
+        self.safety_factor = 1
+        self.subspace_dim = self.num_materials * self.safety_factor  # N_s
+        
 
         # Subspace data for low-rank simulation
         self.subspace_data = np.abs(np.random.randn(self.detector_rows, self.detector_columns, self.subspace_dim)).astype(np.float32)
@@ -59,7 +62,7 @@ class TestHSNT(unittest.TestCase):
 
     def test_dehydrate_with_fixed_subspace_dimension(self):
         """Dehydrate with fixed subspace dimension should produce outputs with expected shapes."""
-        dehydrated = hsnt.dehydrate(self.clean, subspace_dimension=self.subspace_dim, verbose=0)
+        dehydrated = hsnt.dehydrate(self.clean, num_materials=self.num_materials, safety_factor=self.safety_factor, verbose=0)
         self.assertIsInstance(dehydrated, list)
         subspace_data, subspace_basis, dataset_type = dehydrated
         self.assertEqual(subspace_data.shape[-1], self.subspace_dim)
@@ -72,7 +75,7 @@ class TestHSNT(unittest.TestCase):
     def test_hyper_denoise_reduces_noise(self):
         """hyper_denoise should reduce noise relative to noisy input."""
         before_std = np.std(self.noisy - self.clean)
-        denoised = hsnt.hyper_denoise(self.noisy, subspace_dimension=self.subspace_dim, verbose=0)
+        denoised = hsnt.hyper_denoise(self.noisy, num_materials=self.num_materials, safety_factor=self.safety_factor, verbose=0)
         self.assertEqual(denoised.shape, self.noisy.shape)
         after_std = np.std(denoised - self.clean)
         self.assertLess(after_std, before_std, f"Denoising did not reduce noise (before={before_std}, after={after_std})")
@@ -81,7 +84,7 @@ class TestHSNT(unittest.TestCase):
         """Estimate subspace dimension on the setup data."""
         # reshape to 2D (pixels x wavelengths)
         X = self.clean.reshape(-1, self.wavelengths)
-        est = hsnt._estimate_subspace_dimension(X, safety_factor=1, verbose=0)
+        est = hsnt._estimate_subspace_dimension(X, safety_factor=self.safety_factor, verbose=0)
         self.assertIsInstance(est, int)
         self.assertGreaterEqual(est, 1)
         self.assertLessEqual(est, self.wavelengths)  # can't exceed wavelengths


### PR DESCRIPTION
# Major changes
1. Improved transmission mode by increasing the epsilon value and adding a pre-cleanup step.
2. Introduced the parameter num_materials and removed subspace_dimension.

# How to test the changes
1. Switch to the hsnt_dev branch and install mbirjax.
2. Create the folder: mbirjax/experiments/hsnt/input_data
3. Copy the two files from depot/bouman/data/ORNL/hsnt/transmission_data into mbirjax/experiments/hsnt/input_data
4. Run: mbirjax/experiments/hsnt/mini_example_transmission.py