### PR TITLE
Log version number as part of recon.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ experiments/hsnt/processed_data/*
 
 experiments/translation/output/*
 
+experiments/fit_bh_curve/demo_data/*
+
 tests_data_dependent/data/*
 
 # ignore jupyter notebook files

--- a/mbirjax/cone_beam.py
+++ b/mbirjax/cone_beam.py
@@ -1131,6 +1131,7 @@ class ConeBeamModel(TomographyModel):
                                                                  first_iteration=first_iteration,
                                                                  compute_prior_loss=compute_prior_loss,
                                                                  logfile_path=logfile_path, print_logs=print_logs)
+        recon_top_half = jax.device_get(recon_top_half)
         if init_recon is not None:
             bot_init_recon = init_recon[:, :, -bot_recon_shape[2]:]
         else:
@@ -1141,6 +1142,7 @@ class ConeBeamModel(TomographyModel):
                                                                  first_iteration=first_iteration,
                                                                  compute_prior_loss=compute_prior_loss,
                                                                  logfile_path=logfile_path, print_logs=print_logs)
+        recon_bot_half = jax.device_get(recon_bot_half)
         # -------- Stitch together top and bottom reconstructions --------
         recon_full = mj.stitch_arrays([recon_top_half, recon_bot_half], overlap=2 * half_overlap_recon, axis=2)
 

--- a/mbirjax/tomography_model.py
+++ b/mbirjax/tomography_model.py
@@ -19,9 +19,10 @@ from jax.errors import JaxRuntimeError
 import jax
 import jax.numpy as jnp
 
-import mbirjax
 import mbirjax as mj
 from mbirjax import ParameterHandler
+
+from importlib.metadata import version, PackageNotFoundError
 
 jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
 # Set the GPU memory fraction for JAX
@@ -79,6 +80,12 @@ class TomographyModel(ParameterHandler):
         self.use_gpu = 'none'  # This is set in set_devices_and_batch_sizes based on memory and get_params('use_gpu')
         self.set_devices_and_batch_sizes()
         self.create_projectors()
+        try:
+            __version__ = version("mbirjax")
+        except PackageNotFoundError:
+            # package is not installed
+            __version__ = "unknown"
+        self.version = __version__
 
     @classmethod
     def get_required_param_names(cls):
@@ -954,6 +961,7 @@ class TomographyModel(ParameterHandler):
         # Initialize logging for this run
         if first_iteration == 0 or self.logger is None:
             self.setup_logger(logfile_path=logfile_path, print_logs=print_logs)
+        self.logger.info('MBIRJAX Version = {}'.format(self.version))
         self.logger.info('GPU used for: {}'.format(self.use_gpu))
         self.logger.info('Estimated GPU memory required = {:.3f} GB, available = {:.3f} GB'.format(self.mem_required_for_gpu, self.gpu_memory))
         self.logger.info('Estimated CPU memory required = {:.3f} GB, available = {:.3f} GB'.format(self.mem_required_for_cpu, self.cpu_memory))


### PR DESCRIPTION
Get the version number from pyproject.toml and include it in recon output. 
Also fix bug in split_sino_recon.  The problem was that in some edge cases, one half would be reconstructed with use_gpu=full, so the recon would end up on the gpu, while the other half would have use_gpu=sinograms, so the recon would end up on the cpu.  The solution is to move each recon to the cpu after each recon, which saves gpu memory and allows for the stitching of the two halves to work correctly.  