### PR TITLE
Describe jax rounding/lax map scatter bug.

### DIFF
--- a/experiments/bugs_and_artifacts/jax rounding bug/jax_rounding_bug.md
+++ b/experiments/bugs_and_artifacts/jax rounding bug/jax_rounding_bug.md
@@ -1,0 +1,387 @@
+# JAX/XLA rounding bug — overview, resolution, and implementation plan
+
+*Companion to `jax_rounding_bug_v2.py` (this directory) and
+`minimal_lax_map_repro.{py,md}` (in `./lax_map_scatter_bug/`).
+Investigation 2026-05-25/26; JAX 0.10.1.*
+
+---
+
+## Table of contents
+
+- [1. The problem](#1-the-problem)
+- [2. What we tried (summary)](#2-what-we-tried-summary)
+- [3. The resolution](#3-the-resolution)
+- [4. Implementation plan](#4-implementation-plan)
+    - [4.1 Where the precompute lives](#41-where-the-precompute-lives)
+    - [4.2 Geometry-specific computation: subclass overrides](#42-geometry-specific-computation-subclass-overrides)
+    - [4.3 Compatibility with future sharding](#43-compatibility-with-future-sharding)
+    - [4.4 API changes — places to update](#44-api-changes--places-to-update)
+    - [4.5 Other call sites with the bug precondition](#45-other-call-sites-with-the-bug-precondition)
+    - [4.6 Testing](#46-testing)
+    - [4.7 Open questions for the design discussion](#47-open-questions-for-the-design-discussion)
+- [5. Status](#5-status)
+- [6. Files](#6-files)
+
+---
+
+## 1. The problem
+
+The mbirjax forward projector (`forward_project_pixel_batch_to_one_view`
+in `parallel_beam.py`) computes an integer scatter destination
+`n_p_center = jnp.round(n_p).astype(int32)` *inside* the jit boundary,
+where `n_p` is the continuous projected channel coordinate derived
+from `cos`/`sin` of the view angle.  Under certain combinations of
+outer wrappers — specifically `jax.vmap` (over views) wrapping
+`jax.lax.map` (over slice batches) wrapping a scatter-add — XLA's
+optimized HLO produces incorrect results for specific pixel-cloud /
+view-angle combinations.
+
+**Symptom:** an antisymmetric channel error in the sinogram —
+excess at `n_pc − 1`, deficit at `n_pc + 1` — of magnitude
+≈ 0.5 per affected pixel, totaling ≈ 1.7 intensity units summed
+across the affected pixel cluster.  In the production demo this fires
+at views 12 and 134 (of 180) when the ROR-masked pixel batch 8
+(rows 91..99 of a 256×256 recon) is being projected.
+
+**The algorithm is mathematically continuous** in `n_p`: the PSF's
+boundary clipping makes the projection independent of which side
+`round()` picks at exact half-integers.  So this is a real
+implementation bug, not a numerical-sensitivity artifact.
+
+**The error pattern looks exactly like** the scatter destination
+`n = n_pc + offset` and the L-weight's `abs_d = |n_p − n|` disagreeing
+on what `n_pc` is — as if `n_pc` were computed twice in XLA's lowering
+and the two copies diverged at exact half-integers.  However direct
+probes (returning `n_pc + {−1, 0, +1}` from the `lax.map` body)
+showed those three values are internally consistent, and an
+`optimization_barrier` placed on `n_pc` did **not** fix the bug.  So
+the precise XLA failure mechanism is **not** "CSE-failed round" of the
+kind we (and presumably the upstream JAX/XLA team) have seen before.
+It remains undetermined.
+
+**What we know with certainty** is the precondition for the bug:
+`jnp.round` of a continuous, in-jit-derived `n_p` must live inside
+the `vmap → lax.map → scatter` chain.  Take any one of those three
+nesting levels away — or precompute `n_pc` on the host so the `round`
+doesn't appear inside the chain at all — and the bug vanishes.
+
+The full investigation, with all 15 test variants and the HLO
+post-mortem, is in `../lax_map_scatter_bug/minimal_lax_map_repro.md`.
+
+---
+
+## 2. What we tried (summary)
+
+Run by `../lax_map_scatter_bug/minimal_lax_map_repro.py`, which sweeps
+all 24 ROR-masked pixel batches of a 256×256 recon under `vmap` of
+size 1 over view 12, with `lax.map` over `_NB = 8` slice batches.
+
+| Fix attempt | Result                                                                    |
+|---|---------------------------------------------------------------------------|
+| Vanilla `jnp.round` (baseline)                                          | BAD=8 fires, magnitude 0.4995                                             |
+| `safe_round(scale=1e-4)`  (snap-then-perturb past half-integer)         | Moves bug to BAD=18                                                       |
+| `safe_round(scale=1e-6)`                                                | Sub-ULP perturbation → no-op → BAD=8 fires                                |
+| `jnp.round` + `jax.lax.optimization_barrier(n_pc)`                      | BAD=8 fires (barrier ineffective)                                         |
+| `safe_round + optimization_barrier`                                     | BAD=18 fires (same as safe_round alone)                                   |
+| `safe_round_f64` (cast to float64 inside, scales 1e-4 / 1e-6 / 1e-8)    | Same pattern as float32 — float64 changes nothing                         |
+| **Precompute full geometry tuple, pass in as JAX inputs (T15i)**        | **✓ All 24 batches bit-exact (`max abs(diff) = 0.00e+00)`**               |
+| **Precompute `n_pc` only, leave rest of geom in-jit (T15j)**            | **✓ All 24 batches clean (worst `max abs(diff) = 6.3e-05`, float noise)** |
+
+`lax.map → vmap` (the other workaround we considered) also fixes the
+bug, but at the cost of restricting the code's expressiveness.
+
+---
+
+## 3. The resolution
+
+**Precompute the integer scatter index (`n_p_center` in parallel beam,
+`(n_p_center, m_p_center, k_m_center)` in cone beam) on the host, and pass it
+into the jit'd projector as an input.**  Leave the rest of the
+geometry derivation (`cos`/`sin`/`n_p`/`W_pc`/`cos_alpha`/`L_max`)
+inside the jit unchanged.
+
+T15j confirms this is the smallest change that works.  The bug
+requires the `jnp.round` to live inside the `vmap + lax.map + scatter`
+chain; precomputing `n_pc` removes that single ingredient.
+
+**Why this is preferable to `lax.map → vmap`:**
+
+- No structural restriction on the code.  Future contributors can use
+  `lax.map` (and `lax.scan`, `lax.fori_loop`, etc.) freely.  The rule
+  becomes a localized API contract — "the projector takes the integer
+  scatter destinations as inputs" — rather than a folk wisdom about
+  which JAX primitives to avoid.
+- Preserves the cache-locality benefit of the inner `_B` slice
+  batching in `lax.map`.
+- Generalizes cleanly to cone beam, which has additional integer
+  scatter indices and where switching the inner loop to `vmap` would
+  be more expensive (more memory pressure from vectorizing across
+  slice / channel batches).
+
+**Memory cost:** for parallel beam, per call to the jit'd projector,
+one extra `int32[num_views_in_batch, num_pixels_in_batch]`.  At
+typical sizes that's tens to hundreds of KB — negligible.  Cone beam
+adds a second `int32` array of similar size.
+
+---
+
+## 4. Implementation plan
+
+This section is an outline, not a final spec.  It identifies the
+moving parts and the questions that need to be answered before writing
+code.
+
+### 4.1 Where the precompute lives
+
+`sparse_forward_project` and `sparse_back_project` already iterate
+over (pixel-batch × view-batch) tiles with a Python `for` loop on the
+host.  That is the natural place to precompute the integer scatter
+indices: outside the jit boundary, in plain numpy (or JAX with
+`jax.disable_jit()` if we want JAX's `cos`/`sin` for bit-exact match,
+but numpy is simpler), once per tile, before invoking the jit'd
+projector kernel for that tile.
+
+Same story on the back-projection side — the integer indices used in
+the gather/scatter are the same geometric quantity.
+
+### 4.2 Geometry-specific computation: subclass overrides
+
+The integer scatter indices are geometry-specific:
+
+- **Parallel beam:** `n_p_center(pixel_indices, angle, params) → int32`
+  — one int per pixel per view.
+- **Cone beam:** `(n_p_center, m_p_center, k_m_center)(pixel_indices, angle, params)
+  → (int32, int32)` — two ints per pixel per view (channel and row).
+
+Proposed structure: a base-class method on `TomographyModel`:
+
+```python
+def precompute_scatter_indices(self, pixel_indices, angles):
+    """Compute the integer scatter destinations needed by
+    forward/back projection.  Geometry-specific; must be overridden
+    by each subclass.
+
+    Returns a geometry-specific object (e.g. a NamedTuple) whose
+    fields are passed individually into the jit'd projector
+    kernels as additional arguments.
+
+    Implementations run on the host (numpy) so that the round
+    operation does not appear inside any jit boundary.
+    """
+    raise NotImplementedError
+```
+
+`ParallelBeamModel.precompute_scatter_indices` returns one int32
+array `n_p_center` of shape `(num_views, num_pixels)`.
+`ConeBeamModel.precompute_scatter_indices` returns the
+`(n_p_center, m_p_center)` pair.
+
+The jit'd projector kernels (`forward_project_pixel_batch_to_one_view`,
+its back-projection sibling, and the cone-beam analogs) take these
+arrays as new required arguments and stop calling
+`compute_proj_data` for the integer part.  `compute_proj_data`
+either splits in two (a float-only version stays in-jit, an
+integer-only version moves out) or is wrapped at the call sites.
+
+### 4.3 Compatibility with future sharding
+
+In the planned final pipeline (see `.claude/status.md`), the sinogram
+is sharded along `det_rows` and the recon along `slices`.  Critically:
+
+- The integer scatter indices depend only on `(pixel_coords, view_angles,
+  geometry_params)`.
+- They do **not** depend on `det_rows` (parallel beam) or on
+  individual slices.
+
+So precomputed indices are **invariant under the sharding axes for
+both sinogram and recon**.  Each device that owns a slice of the
+recon needs the indices for the pixel batches it is projecting — but
+those indices are identical across devices for the same pixel set.
+
+**Storage flexibility.**  The precomputed indices do *not* have to be
+numpy arrays.  JAX arrays — including `NamedSharding` arrays
+distributed across devices — are fine, as long as the values are
+**concrete** (materialized in memory, host or device) by the time they
+arrive at the projector's jit boundary.  The bug requires the round
+operation to be *traced* inside the projector's jit; if the indices
+arrive as a concrete `jax.Array` (already-computed values rather than
+tracers), the round chain doesn't exist inside the jit and the
+precondition is broken.  This means we can use whatever storage and
+sharding strategy fits naturally with how the indices are produced and
+consumed.
+
+Two reasonable approaches:
+
+1. **Compute once on the host, replicate to every device.**  Simplest.
+   The indices are small (an int32 array of `num_views × num_pixels`)
+   so the replication cost is negligible.
+2. **Compute on each device for its local pixel set.**  Slightly more
+   complex but avoids the host→device transfer.  Each device's
+   threaded worker (Path G threading, per the sharding plan) computes
+   its own indices and ships them to its device alongside its
+   sinogram/recon shard.
+
+The choice can be deferred — the API (a function that returns the
+indices) is the same either way.
+
+### 4.4 API changes — places to update
+
+Approximate (need to confirm exact signatures when implementing):
+
+- `tomography_model.py`:
+  - Add abstract `precompute_scatter_indices(pixel_indices, angles)`.
+  - Modify `sparse_forward_project` / `sparse_back_project` to call
+    `precompute_scatter_indices` once per (pixel_batch, view_batch)
+    tile before invoking the jit'd projector, and to pass the result
+    into the jit'd kernel as an additional argument.
+- `parallel_beam.py`:
+  - Override `precompute_scatter_indices` to return `n_p_center`.
+  - Modify `forward_project_pixel_batch_to_one_view` and its
+    back-projection sibling to take `n_p_center` as an argument and
+    drop the in-jit `jnp.round`.
+  - Audit `compute_proj_data`: the float outputs (`n_p`, `W_p_c`,
+    `cos_alpha_p_xy`) stay in-jit; the integer output
+    (`n_p_center`) leaves and is computed by the new host-side method.
+- `cone_beam.py`:
+  - Same pattern, returning both `n_p_center` and `m_p_center`.
+  - Three known `jnp.round`-of-continuous-geometry sites at lines
+    401, 625, 688 (per earlier discussion).  Each becomes an input
+    rather than an in-jit computation.
+
+### 4.5 Other call sites with the bug precondition
+
+The same precondition (`jnp.round` of an in-jit-derived continuous
+projection coordinate, used to compute a scatter destination) exists
+at multiple sites across the geometry kernels.  We take the operating
+position that **any of these could exhibit the bug under the right
+combination of input layout, view angles, and outer wrappers** —
+some hit cleanly today, others may not, others may start hitting
+after a future JAX/XLA update.  Rather than verify each site
+individually, the plan is to apply the precompute pattern uniformly
+to all of them.
+
+Full inventory:
+
+| File | Line | Function | Notes |
+|---|---|---|---|
+| `parallel_beam.py` | (the original failure) | `forward_project_pixel_batch_to_one_view` | `n_p_center` closed over outside the `lax.map` body |
+| `cone_beam.py` | 401 | (per earlier audit) | |
+| `cone_beam.py` | 625 | (per earlier audit) | |
+| `cone_beam.py` | 688 | (per earlier audit) | |
+| `multiaxis_parallel.py` | 251 | `forward_vertical_fan_one_pixel_to_one_view` | `m_center` inside `lax.map` body, varies per iter |
+| `multiaxis_parallel.py` | 303 | `forward_horizontal_fan_pixel_batch_to_one_view` | round at top of function, no inner `lax.map` |
+| `multiaxis_parallel.py` | 365 | `back_horizontal_fan_one_view_to_pixel_batch` | round at top of function |
+| `multiaxis_parallel.py` | 436 | `back_vertical_fan_one_view_to_one_pixel` | inside `lax.map` body |
+| `translation_model.py` | 332 | inside `create_det_column_rows` (a `lax.map` body) | |
+| `translation_model.py` | 553 | `compute_vertical_data_single_pixel` | |
+| `translation_model.py` | 605 | `compute_horizontal_data` | |
+
+The sites span two structural variants:
+- Round of a value **closed over** outside the `lax.map` (parallel_beam
+  pattern; confirmed bug-triggering).
+- Round of a value **computed inside** the `lax.map` body, varying per
+  scan iteration (multiaxis vertical fans; translation_model
+  `create_det_column_rows`).  Whether these trigger the same XLA
+  mis-optimization is not yet directly tested, but the precondition
+  is in the same family.
+
+Also includes sites where the round is at the top of the function with
+no inner `lax.map` (multiaxis horizontal fans).  Those are safer as
+written, but precomputing the integer there too costs nothing,
+removes structural ambiguity, and keeps the API uniform across
+geometries — so they get the same treatment in the rewire.
+
+### 4.6 Testing
+
+- The bug demo (`vmap_lax_map_demo.py`) and minimization script
+  (`minimal_lax_map_repro.py`) both already reproduce the original
+  failure; they should serve as regression tests for the fix.
+  Specifically, T15j is the test that exercises the proposed fix
+  pattern.
+- Re-run the standard parallel-beam test suite against the prerelease
+  baseline.  The 3-pixel +x/0/−x error pattern that originally
+  motivated this investigation should disappear.
+- Equivalent cone-beam regression tests once the cone-beam sites are
+  patched.
+
+### 4.7 Open questions for the design discussion
+
+1. **Naming / structure of the precomputed object.**  A `NamedTuple`
+   keeps the parallel-vs-cone API uniform (each geometry packages its
+   own fields, the caller doesn't care).  Alternatives: a dict, or
+   separate positional arguments.  The latter is cleaner for jit
+   tracing but uglier when the field count differs across geometries.
+
+2. **Caching across iterations.**  Within a single VCD reconstruction,
+   the indices for a given (pixel-batch, view) are constant.
+   Recomputing them every iteration is wasteful.  Should they be
+   cached on `self`?  If so, invalidation rules — they're invalidated
+   by any geometry-parameter change (angles, voxel size, detector
+   offsets, …).  The caching itself looks straightforward; the cost
+   is the invalidation hooks in `set_params` and the increased state
+   on the model object.  Probably worth doing but not blocking.
+
+3. **The "concrete inputs" contract.**  The precomputed indices must
+   reach the jit'd projector as concrete `jax.Array` or numpy values
+   — not as tracers from an outer jit.  In current production
+   `sparse_forward_project` / `sparse_back_project` are plain Python
+   loops, so this is satisfied automatically.  If a future change
+   wraps either function in `jit`, the precompute logic disappears
+   into the outer trace and the bug returns silently.  Worth
+   documenting in the projector's docstring and possibly adding a
+   runtime assertion that the integer-index argument is not a tracer.
+
+4. **Uniform geometry-specific interface.**  Each geometry has more
+   than one integer scatter index it needs to precompute (e.g.
+   cone-beam has `n_p_center` and `m_p_center`; translation_model has
+   `n_p_center`, `m_p_center`, and `k_m_center` for the various
+   inside-the-`lax.map`-body sites).  The `precompute_scatter_indices`
+   method needs to return a geometry-specific container holding all
+   of them, and each downstream projector kernel needs to know which
+   fields to consume.  This is mostly mechanical but does require
+   touching each kernel signature.  Worth designing the container
+   (NamedTuple per geometry?) so the kernel call sites are clean.
+
+5. **Host-side compute parity with the device-side `jnp.cos` /
+   `jnp.sin`.**  When the precompute runs in `numpy`, the float
+   arithmetic may differ from `jnp` in the last bit or two.  The
+   result is still an integer (via `round`), so this matters only at
+   exact half-integer boundaries — exactly the boundaries the
+   precompute is meant to handle deterministically.  Worth a quick
+   sanity test that the integer output matches between
+   `numpy.round(numpy.cos(angle) * xt - ...)` and the equivalent
+   `jnp` chain, on a representative set of (angle, pixel) values.
+   Likely fine, but cheap to verify.
+
+6. **`fbp_filter` / `qggmrf` / other non-geometry code paths.**  No
+   `jnp.round` inside jit was identified outside the geometry
+   kernels.  Worth a periodic re-audit when new geometry or kernel
+   code is added, since the pattern is easy to introduce
+   accidentally.
+
+---
+
+## 5. Status
+
+- Root cause and fix are known and tested in `minimal_lax_map_repro.py`
+  (T15i / T15j).
+- Production implementation is **not** done.  Awaits coordination with
+  other maintainers per §4.6.
+- Earlier `lax.map → vmap` workaround was considered and rejected in
+  favor of the precompute approach.
+
+---
+
+## 6. Files
+
+- `jax_rounding_bug_v2.py` (this directory) — direct CSE-failure probe.
+  Inconclusive but informative.
+- `../lax_map_scatter_bug/minimal_lax_map_repro.py` — T1–T15j
+  systematic minimization, includes the working fixes.
+- `../lax_map_scatter_bug/minimal_lax_map_repro.md` — investigation
+  notes; should be updated to reference this plan once the implementation
+  lands.
+- `../lax_map_scatter_bug/vmap_lax_map_demo.py` — annotated demo of
+  the original bug.
+- `mbirjax/parallel_beam.py` and `mbirjax/cone_beam.py` — the
+  production sites to be patched (see §4.4).

--- a/experiments/bugs_and_artifacts/jax rounding bug/jax_rounding_bug_v2.py
+++ b/experiments/bugs_and_artifacts/jax rounding bug/jax_rounding_bug_v2.py
@@ -1,0 +1,179 @@
+"""
+jax_rounding_bug_v2.py — direct probe of the CSE-failure hypothesis.
+
+Hypothesis (from `minimal_lax_map_repro.md` §2 + discussion):
+  In the buggy vmap(lax.map(...)) setup, XLA fails to deduplicate
+  `jnp.round(n_p)` and produces multiple copies of `n_pc`.  For `n_p`
+  values exactly at half-integers, those copies can disagree by 1
+  (last-bit float diff in the round input flips the result).  The
+  scatter destination and the L-weight computation then disagree on
+  what `n_pc` is, and contributions land in the wrong channel.
+
+Probe:
+  Inside the bug-triggering lax.map body (T9a setup from
+  minimal_lax_map_repro), in addition to running the buggy scatter,
+  return the three integer arrays  `n_pc - 1`,  `n_pc + 0`,  `n_pc + 1`
+  out of the lax.map.  If XLA was forced to use a single consistent
+  `n_pc`, the three returned arrays will differ from each other by
+  exactly 1 everywhere.  If XLA used three separately-rounded copies,
+  the differences could be 0 or 2 at exactly the half-integer pixels.
+
+Caveat: XLA may CSE the three additions trivially when they appear as
+direct outputs, even though it doesn't CSE the analogous sites that
+feed the scatter / L-weight in the real bug.  If we see all-1 step
+sizes here, that's compatible with the bug being real but only
+manifesting when n_pc is consumed in different fused subgraphs.
+"""
+
+import os, sys
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=1")
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+print("=" * 70)
+print("  jax_rounding_bug_v2.py — CSE-failure probe")
+print("=" * 70)
+print(f"  JAX version    : {jax.__version__}")
+print(f"  default backend: {jax.default_backend()}")
+print()
+
+# ── Setup matching minimal_lax_map_repro.py T9a (the bug-triggering case) ──
+NP, N_ROWS, _B, ND = 2048, 128, 16, 256
+_NB = N_ROWS // _B
+DV_prod, DDC_prod, OFF_prod = 1.0, 1.0, 0.0
+DCC_prod = (ND - 1) / 2.0
+recon_shape = (256, 256, 128)
+N_VIEWS = 180
+angles_full = np.linspace(0, np.pi, N_VIEWS, endpoint=False)
+
+
+def get_2d_ror_mask(recon_shape):
+    nr, nc = recon_shape[:2]
+    rc, cc = (nr - 1) / 2, (nc - 1) / 2
+    radius = max(rc, cc)
+    coords = np.meshgrid(np.arange(nc) - cc, np.arange(nr) - rc)
+    return coords[0] ** 2 + coords[1] ** 2 <= radius ** 2
+
+
+def gen_pixel_partition(recon_shape):
+    nr, nc = recon_shape[:2]
+    indices = np.arange(nr * nc, dtype=np.int32)
+    mask = get_2d_ror_mask(recon_shape).flatten()
+    return np.sort(indices[mask == 1])
+
+
+BAD = 8
+all_indices = gen_pixel_partition(recon_shape)
+pb = all_indices[BAD * NP : (BAD + 1) * NP]
+ri, ci = np.unravel_index(pb, recon_shape[:2])
+yt_prod = (DV_prod * (ri - (recon_shape[0] - 1) / 2.0)).astype(np.float32)
+xt_prod = (DV_prod * (ci - (recon_shape[1] - 1) / 2.0)).astype(np.float32)
+xt_jnp = jnp.array(xt_prod)
+yt_jnp = jnp.array(yt_prod)
+
+np.random.seed(0)
+voxel = jnp.array(np.random.rand(NP, N_ROWS).astype(np.float32))
+
+
+def _geom_inline(angle):
+    ct = jnp.cos(angle)
+    st = jnp.sin(angle)
+    x_p   = ct * xt_jnp - st * yt_jnp
+    n_p   = (x_p + OFF_prod) / DDC_prod + DCC_prod
+    n_pc  = jnp.round(n_p).astype(jnp.int32)
+    cos_a = jnp.maximum(jnp.abs(ct), jnp.abs(st))
+    W_pc  = (DV_prod / DDC_prod) * cos_a
+    L_mx  = jnp.minimum(1.0, W_pc)
+    return n_p, n_pc, W_pc, cos_a, L_mx
+
+
+def forward_buggy_with_dests(angle):
+    """T9a's buggy forward, plus return n_pc-1, n_pc+0, n_pc+1 from the lax.map."""
+    n_p, n_pc, W_pc, cos_a, L_mx = _geom_inline(angle)
+    vb_batched = voxel.T.reshape(_NB, _B, NP)
+
+    def body(vb):
+        sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+        # Real bug-triggering scatter chain — unchanged from T9a.
+        for no in (-1, 0, 1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+            A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+            sb    = sb.at[:, n].add(A * vb)
+        # Diagnostic outputs: the three offset destinations.
+        return sb, n_pc + (-1), n_pc + 0, n_pc + 1
+
+    sb_stack, dn1, d0, dp1 = jax.lax.map(body, vb_batched)
+    return sb_stack.reshape(N_ROWS, ND), dn1, d0, dp1
+
+
+def forward_ref_inline(angle):
+    """Reference (no lax.map) — to confirm the bug is present in this setup."""
+    n_p, n_pc, W_pc, cos_a, L_mx = _geom_inline(angle)
+    sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+    for no in (-1, 0, 1):
+        n     = n_pc + no
+        abs_d = jnp.abs(n_p - n)
+        L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+        A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+        sino  = sino.at[:, n].add(A * voxel.T)
+    return sino
+
+
+# ── Run on view 12, with the same vmap wrapper that triggers the bug ──────
+view_idx = 12
+angles_jax = jnp.array(angles_full[[view_idx]].astype(np.float32))
+
+sino_b, dn1, d0, dp1 = jax.jit(jax.vmap(forward_buggy_with_dests))(angles_jax)
+sino_r = jax.jit(jax.vmap(forward_ref_inline))(angles_jax)
+
+# Sanity: confirm the bug is actually triggered in this code path
+md = float(jnp.abs(sino_b - sino_r).max())
+status = "BUG present" if md > 1e-3 else "no bug — test below may not be diagnostic"
+print(f"Sanity check:  buggy vs ref  max|diff| = {md:.4e}   ({status})")
+print()
+
+# ── Check the step sizes between offset destinations ──────────────────────
+dn1_np = np.asarray(dn1[0])   # shape (_NB, NP)
+d0_np  = np.asarray(d0[0])
+dp1_np = np.asarray(dp1[0])
+
+step_low  = d0_np  - dn1_np   # expected 1 everywhere
+step_high = dp1_np - d0_np    # expected 1 everywhere
+
+print(f"step_low  = (n_pc+0) - (n_pc-1):  unique values = "
+      f"{sorted(np.unique(step_low).tolist())}")
+print(f"step_high = (n_pc+1) - (n_pc+0):  unique values = "
+      f"{sorted(np.unique(step_high).tolist())}")
+
+n_bad_low  = int(np.sum(step_low  != 1))
+n_bad_high = int(np.sum(step_high != 1))
+print(f"# cells with step_low  != 1:  {n_bad_low}")
+print(f"# cells with step_high != 1:  {n_bad_high}")
+
+if n_bad_low > 0 or n_bad_high > 0:
+    print("\n✗ INCONSISTENCY DETECTED — three n_pc copies disagree.")
+    bad_mask = (step_low != 1) | (step_high != 1)
+    bb, pp = np.where(bad_mask)
+    print(f"  Total inconsistent cells: {bad_mask.sum()}.  First 10:")
+    # Also show the n_p value at those pixels to confirm half-integer
+    n_p_np = np.asarray(_geom_inline(angles_jax[0])[0])
+    for b, p in list(zip(bb, pp))[:10]:
+        print(f"    batch={b:>2d}  pixel={p:>4d}  "
+              f"dn1={dn1_np[b,p]:>4d}  d0={d0_np[b,p]:>4d}  dp1={dp1_np[b,p]:>4d}  "
+              f"n_p={n_p_np[p]:.6f}")
+else:
+    print("\n✓ All three destinations differ by exactly 1 — XLA used a")
+    print("  consistent n_pc here.  Two interpretations:")
+    print("    (a) returning these values forced CSE that wouldn't otherwise win, or")
+    print("    (b) the inconsistency happens elsewhere (e.g., between the")
+    print("        scatter-index path and the L-weight path), not between the")
+    print("        three offset increments.")
+
+print()
+print("=" * 70)
+print("Done.")
+print("=" * 70)

--- a/experiments/bugs_and_artifacts/jax rounding bug/lax_map_scatter_bug/minimal_lax_map_repro.md
+++ b/experiments/bugs_and_artifacts/jax rounding bug/lax_map_scatter_bug/minimal_lax_map_repro.md
@@ -1,0 +1,278 @@
+# `lax.map` + scatter-add bug — investigation notes
+
+*Companion to `minimal_lax_map_repro.py` and `vmap_lax_map_demo.py`.*
+*Investigated 2026-05-25/26.  JAX 0.10.1, CPU backend, Apple Silicon (arm64).*
+
+---
+
+## 1. Symptom (production)
+
+In mbirjax's parallel-beam forward projector
+(`forward_project_pixel_batch_to_one_view`), an inner `jax.lax.map` over
+`_NB` slice batches produces incorrect sinogram values for specific view
+angles when called via the outer `vmap`-over-views machinery in
+`sparse_forward_project`.
+
+Concretely, with the production geometry
+`ParallelBeamModel((180, 128, 256))` and pixel batch 8 of
+`gen_full_indices(recon_shape)`:
+
+- max|diff| vs the prerelease scatter ≈ **1.7** (visible reconstruction
+  artifact, not float-noise).
+- The error appears only at angles **12** and **134** of 180.
+- The error is antisymmetric: excess at channel `n_pc − 1`, zero at
+  `n_pc`, deficit at `n_pc + 1`.
+- Visible only for PSF offsets ±1; offset 0 is always clean.
+
+---
+
+## 2. Root cause (as far as we've reduced it)
+
+The bug lives **strictly below JAX's JAxPR level**.
+
+- The scan-body JAxPRs for "geometry derived from `angle`" and "geometry
+  passed as explicit `vmap` args" are *bitwise identical* (115 lines).
+- Replacing `jax.lax.map(f, xs)` with `jax.vmap(f)(xs)` (same semantics,
+  different XLA lowering) eliminates the bug.
+- Replacing `lax.map` with a Python for-loop also eliminates the bug.
+
+The HLO dive (`/tmp/hlo_demo/`, see "HLO findings" below) shows the
+scatter dim-numbers, bounds checks, and arithmetic are identical between
+the reference and buggy paths.  The only structural difference is that
+the buggy path's scatter is wrapped inside a `while` loop (`lax.map`'s
+lowering) and operates on a `[2, 16, 256]` per-batch slab instead of the
+reference's `[2, 128, 256]` whole-view buffer.  We did not find a smoking
+gun in the HLO or LLVM IR.
+
+**The algorithm is continuous in `n_p`.** For an `n_p` exactly at a
+half-integer, the PSF clipping makes the result independent of which
+side `round()` picks — both `n_pc = round_up` and `n_pc = round_down`
+deposit the same total energy into the same two adjacent channels.
+So the observed ~1.7-magnitude output difference is *not* a sensitivity
+artifact at a discontinuous boundary; it is a real bug.
+
+**The observed error signature** — excess at `n_pc − 1`, zero at
+`n_pc`, deficit at `n_pc + 1`, with magnitude consistent with one
+pixel's L-weight (~0.5) per affected pixel — is what you would see if
+the integer scatter destination `n = n_pc + offset` and the float
+`abs_d = |n_p − n|` (which feeds the L-weight) were computed against
+**different copies of `n_pc`** that disagree by 1.  That can happen
+when XLA fails to deduplicate `jnp.round(n_p)` and the duplicate
+chains' upstream float arithmetic produces last-bit-different results
+that flip the rounding at exact half-integers.  A similar JAX bug was
+observed in this codebase in the past (now resolved by upstream
+changes); the symptom matches.
+
+**What we directly verified vs. what we did not.**  `jax_rounding_bug_v2.py`
+(in the `jax rounding bug/` subdir) reproduces the bug in this setup
+(`max|diff| ≈ 0.5`) and additionally returns the three offset destinations
+`n_pc − 1`, `n_pc`, `n_pc + 1` from inside the `lax.map` body.  Those three
+arrays differ from each other by exactly 1 everywhere — so within a single
+offset block, the three offset-additions of `n_pc` are mutually consistent.
+That rules out the most aggressive form of the CSE-failure story
+(separately-rounded `n_pc` per offset block) but is compatible with a
+narrower form: the integer path that produces the scatter index and the
+float path that produces the L-weight could still draw from different
+`n_pc` copies inside a single offset block.  We did not find a way to
+directly probe that without modifying the buggy chain itself, and we
+stopped digging at that point.
+
+**Status of the root-cause claim:** the empirical signature and the
+mechanism are consistent, but our probe is suggestive rather than
+conclusive.  The fix below works regardless.
+
+---
+
+## 3. The minimal-failing configuration
+
+The full reduction is in `minimal_lax_map_repro.py`.  Required
+ingredients (anything else removed):
+
+| Ingredient | Required? | Evidence |
+|---|---|---|
+| `use_ror_mask=True` (circular pixel mask) | **yes** | T10 (False) → clean |
+| Pixel **batch 8** of the 256×256 ROR-masked recon | **yes** | T14: 23 of 24 batches are clean |
+| `vmap` outer wrapper (size ≥ 1) | **yes** | T9b (jit only, no vmap) → clean |
+| `lax.map` inner slice batching | **yes** | replacing with `vmap` → clean (`forward_fixed` in demo) |
+| PSF kernel with offsets ±1 around `n_pc` | **yes** | offset 0 alone → clean |
+| `n_p` derived in-jit from `angle` via `cos/sin` (vs precomputed numpy) | **yes in my setup** | T8 (precomputed) → clean; T9b (in-jit) → clean *without* vmap; T9a (in-jit) **bugs** with vmap |
+
+**Smallest reproducer:** `vmap` of size 1 over view 12 with the
+256×256/ROR/batch-8 pixel cloud reproduces the bug at full magnitude
+(`max|diff| ≈ 0.5`).  No `_geom`-related randomness, no second view,
+no production model — just the local `gen_pixel_partition` (≈30 lines,
+mbirjax-free) and the PSF scatter chain.
+
+---
+
+## 4. Workaround
+
+**Replace `jax.lax.map(f, xs)` with `jax.vmap(f)(xs)`.**  Both iterate
+`f` over the leading axis of `xs`; `vmap` lowers via a different XLA
+path that does not exhibit the bug.
+
+In `parallel_beam.py`, line 541
+(`forward_project_pixel_batch_to_one_view`, the `else` branch of the
+`num_batches == 1` guard):
+
+```python
+# BEFORE
+sino_batched = jax.lax.map(project_slice_batch, voxel_batched)
+
+# AFTER
+sino_batched = jax.vmap(project_slice_batch)(voxel_batched)
+```
+
+**Tradeoffs:**
+- `lax.map` was chosen for cache locality (sequential execution, one
+  `(_B, ND)` scatter target in L1 at a time).  `vmap` may materialize
+  all `num_batches × _B × ND` outputs simultaneously and lose that
+  benefit — but in our case `num_batches × _B × ND = 8 × 16 × 256` ≈
+  512 KB per view, negligible.
+- Memory:  fine on all expected backends.
+- Correctness: confirmed in `vmap_lax_map_demo.py` (`forward_fixed` →
+  `max|diff| = 0`).
+
+**Alternative:** remove inner slice batching entirely (the prerelease
+behaviour — one big scatter per view).  This is what the
+`num_batches == 1` guard already does for the small-recon case.
+
+---
+
+## 5. Test results from `minimal_lax_map_repro.py`
+
+```
+T1   single half-integer n_p, no vmap                                    ok
+T2   all n_p exactly at half-integers, no vmap                           ok
+T3   T2 + vmap over 2 synthetic 'views'                                  ok
+T4   all 2048 pixels collide on channel 172 (n_p = 171.5)                ok
+T4b  T4 + 1e-3 perturbation                                              ok
+T5   cos/sin chain on rectangular integer grid, four angles              ok
+T6   T5 + vmap over [12, 134] with rectangular grid                      ok
+T7   circular ROR mask (radius 128, slightly larger than mbirjax's)      ok
+T8   production (xt,yt) from gen_pixel_partition, no vmap                ok
+T9a  production (xt,yt) + in-jit n_p + vmap over [12, 134]               BUG  max|diff|=0.4995
+T9b  same as T9a but no vmap                                             ok
+T10  use_ror_mask=False with vmap[12,134]                                ok
+T11a vmap[12]   (single view in vmap)                                    BUG  max|diff|=0.4995
+T11b vmap[134]  (single view in vmap)                                    BUG  max|diff|=0.4995
+T12a vmap[12, 0]   (paired with a clean view)                            BUG
+T12b vmap[12, 12]  (paired with itself)                                  BUG
+T13  smaller ROR-masked recons (128² and 64²) with batch 0               ok
+T14  BAD scan on 256×256 ROR vmap[12]:  only BAD=8 (rows 91..99) bugs    23/24 clean, 1 BUG
+```
+
+`run_vmap` reports the maximum absolute difference between the
+reference scatter and the `lax.map` scatter on the same inputs;
+`max|diff| < 1e-3` is treated as "clean" (float-summation noise).
+
+---
+
+## 6. Things ruled out
+
+- **Half-integer `n_p` values alone.**  T2 (all 2048 pixels at exact
+  half-integers) and T4 (all colliding on channel 172) are both clean.
+- **Pure duplicate-index pressure.**  T4 puts maximum scatter-add
+  pressure on one channel: clean.
+- **The `cos/sin` derivation chain alone.**  T5 with a rectangular
+  integer grid, including view 90 where all 2048 `n_p` land on exact
+  half-integers, is clean.
+- **The combination "ROR + cos/sin + production geometry params"**, as
+  long as `vmap` is absent.  T8 / T9b clean.
+- **Recon size (independent of pixel layout).**  T13 with 128×128 and
+  64×64 ROR-masked recons (batch 0) is clean.  But this is confounded
+  with pixel set — smaller discs have entirely different pixel batches.
+
+---
+
+## 7. Things confirmed required
+
+- **`use_ror_mask=True`.**  This restricts `gen_pixel_partition` to a
+  circular subset of pixels, producing a specific `(xt, yt)` cloud per
+  batch.  Toggling it to False in the demo (and in T10) eliminates the
+  bug.
+- **The specific pixel batch.**  Of 24 batches in the 256×256 ROR,
+  *only* batch 8 (rows 91..99) triggers the bug for view 12.  Other
+  batches are clean to float-noise level.
+- **An outer `vmap` wrapper.**  `vmap` of size 1 is sufficient.  Plain
+  `jit` without `vmap` does not trigger the bug.
+- **The PSF kernel with offsets ±1.**  Offset 0 alone is clean.
+
+---
+
+## 8. HLO findings (summary)
+
+Dump command:
+```bash
+XLA_FLAGS="--xla_dump_to=/tmp/hlo --xla_dump_hlo_as_text" \
+  python experiments/sharding/vmap_lax_map_demo.py
+```
+
+Three relevant modules:
+- `module_0038.jit_forward_ref` — reference path
+- `module_0040.jit_forward_buggy` — `lax.map` path
+- `module_0042.jit_forward_fixed` — `vmap` path (fix)
+
+**HLO-level observations:**
+- Scatter dim-numbers are identical between ref and buggy
+  (`update_window_dims={1,2,3}`, `inserted_window_dims={}`,
+  `scatter_dims_to_operand_dims={0,2}`, `index_vector_dim=1`).
+- Both paths recompute `round-nearest-even(n_p) → s32` for each PSF
+  offset (XLA does not hoist or share these).
+- Bounds checks (`n >= 0`, `n < ND`) are structurally identical.
+- The fractional `(n_p − n_pc)` is computed identically in both paths
+  by round-tripping `n_pc` through `s32 → f32`.
+
+**Structural differences:**
+- Reference scatter operates on `f32[2, 128, 256]` per view.
+- Buggy scatter operates on `f32[2, 16, 256]` per batch, inside a
+  `while` loop of 8 iterations.  Indices are constant across iterations
+  (the same `s32[4096, 2]` is reused); only the per-batch update slab
+  changes.
+
+**LLVM IR observations:**
+- The buggy scatter kernel processes 16-wide SIMD-vectorized fadds per
+  scatter index.
+- The reference scatter kernel has the same structure but with a
+  16-wide inner × 8-iteration outer loop to cover 128 slices.
+- Both look correct in isolation.  No obviously wrong arithmetic.
+
+We did **not** find a smoking gun in the HLO or LLVM dumps.
+
+---
+
+## 9. Open questions
+
+1. **What is numerically special about batch 8's `(xt, yt)` cloud** that
+   makes the XLA scatter codegen go wrong for it (and not for the
+   other 23 batches at the same recon size)?  Some hypotheses worth
+   testing:
+   - A specific `n_pc` value or duplicate-collision pattern that only
+     occurs at this row range.
+   - A bit-pattern coincidence in the resulting `n_p` array (the float
+     representation, not the value).
+   - An interaction between the `_NB = 8` scan length and the row
+     layout (the batch row count matches the scan length).
+2. **Does any other scan-shaped outer wrapper trigger it?**  E.g.
+   `lax.map(f, angles)` of length 1 instead of `vmap`.  This would
+   widen or narrow the upstream bug story.
+3. **Is this CPU-specific?**  All testing so far is CPU only
+   (Apple Silicon arm64).  Whether GPU or TPU backends are affected
+   has not been checked.
+
+These are not blocking the production fix.  They are useful for an
+upstream bug report.
+
+---
+
+## 10. Files
+
+- `experiments/sharding/vmap_lax_map_demo.py` — annotated demo,
+  reproduces the bug with `max|diff| ≈ 1.68` and shows the fix.
+- `experiments/sharding/minimal_lax_map_repro.py` — minimization
+  script (this document's companion).  Contains a self-contained
+  `gen_pixel_partition` so it has no mbirjax dependency.
+- `experiments/sharding/laxmap_isolation_test.py` — earlier in-tree
+  isolation test that first established the bug exists.
+- `mbirjax/parallel_beam.py` line 541 — the production `lax.map` call
+  that needs the workaround applied.

--- a/experiments/bugs_and_artifacts/jax rounding bug/lax_map_scatter_bug/minimal_lax_map_repro.py
+++ b/experiments/bugs_and_artifacts/jax rounding bug/lax_map_scatter_bug/minimal_lax_map_repro.py
@@ -1,0 +1,1061 @@
+"""
+experiments/sharding/minimal_lax_map_repro.py
+─────────────────────────────────────────────
+Minimal, mbirjax-free reproducer for the lax.scan + scatter-add bug.
+
+Goal: trigger a divergence between
+    REF   :  scatter-add applied directly (outside any scan)
+    BUGGY :  scatter-add applied inside jax.lax.map
+when the input arrays contain an exact-half-integer float "n_p" and
+a closed-over int32 "n_pc" = round(n_p).
+
+The structure mirrors mbirjax's PSF-style projector:
+    for offset in [-1, 0, 1]:
+        n     = n_pc + offset
+        abs_d = |n_p - n|
+        L     = clip((W+1)/2 - abs_d, 0, L_mx)
+        A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+        sb    = sb.at[:, n].add(A * vb_batch)
+
+We run several test variants (T1..T4) of increasing aggressiveness:
+    T1: single half-integer pixel, others random.       No vmap.
+    T2: all n_p exactly at half-integers.               No vmap.
+    T3: T2 + jax.vmap over multiple "views".
+    T4: production-like n_pc pattern (one duplicate channel).
+
+If none repro, we'll discuss what additional ingredient the production
+geometry contributes that this version is missing.
+"""
+
+import os, sys
+import numpy as np
+import jax
+import jax.numpy as jnp
+# Enable float64 so safe_round_f64 variants below can actually use it.
+# All existing tests are explicit float32, so this is benign for them.
+jax.config.update("jax_enable_x64", True)
+
+print("=" * 70)
+print("  minimal_lax_map_repro.py")
+print("=" * 70)
+print(f"  JAX version    : {jax.__version__}")
+print(f"  default backend: {jax.default_backend()}")
+print()
+
+# ── Shapes matching production ────────────────────────────────────────────────
+NP    = 2048
+N_ROWS = 128
+_B    = 16
+_NB   = N_ROWS // _B          # = 8
+ND    = 256
+
+# PSF/geometry constants (numerically representative of a view near angle≈π/15
+# where W_pc≈0.978; these exact values aren't critical, but they put L in a
+# regime similar to production).
+W_pc  = np.float32(0.978)
+L_mx  = np.float32(0.978)
+cos_a = np.float32(0.978)
+DV    = np.float32(1.0)
+
+def get_2d_ror_mask(recon_shape):
+    """
+    Get a binary mask for the region of reconstruction.  By default, the mask is the largest possible circle
+    inscribed on the longest edge of the 2D recon_shape[0:2].
+
+    Args:
+        recon_shape (tuple): Shape of recon in (rows, columns, slices)
+        crop_radius_pixels (int): Number of pixels to subtract from the radius before creating the mask.
+        crop_radius_fraction (float): Fraction to subtract from the radius before creating the mask.
+
+    Returns:
+        A binary mask for the region of reconstruction.
+    """
+    # Set up a mask to zero out points outside the ROR
+    num_recon_rows, num_recon_cols = recon_shape[:2]
+    row_center = (num_recon_rows - 1) / 2
+    col_center = (num_recon_cols - 1) / 2
+
+    radius = max(row_center, col_center)
+
+    col_coords = np.arange(num_recon_cols) - col_center
+    row_coords = np.arange(num_recon_rows) - row_center
+
+    coords = np.meshgrid(col_coords, row_coords)  # Note the interchange of rows and columns for meshgrid
+    mask = coords[0]**2 + coords[1]**2 <= radius**2
+    mask = mask[:, :]
+    return mask
+
+
+def gen_pixel_partition(recon_shape, use_ror_mask=True):
+    """
+    Generates a partition of pixel indices into specified number of subsets for use in tomographic reconstruction algorithms.
+    The function ensures that each subset contains an equal number of pixels, suitable for VCD reconstruction.
+
+    Args:
+        recon_shape (tuple): Shape of recon in (rows, columns, slices)
+        use_ror_mask (bool): Flag to indicate whether to mask out a circular RoR
+
+    Raises:
+        ValueError: If the number of subsets specified is greater than the total number of pixels in the grid.
+
+    Returns:
+        jnp.array: A JAX array where each row corresponds to a subset of pixel indices, sorted within each subset.
+    """
+    # Determine the 2D indices within the RoR
+    num_recon_rows, num_recon_cols = recon_shape[:2]
+    max_index_val = num_recon_rows * num_recon_cols
+    indices = np.arange(max_index_val, dtype=np.int32)
+
+    # Mask off indices that are outside the region of reconstruction
+    if use_ror_mask:
+        mask = get_2d_ror_mask(recon_shape)
+        mask = mask.flatten()
+        indices = indices[mask == 1]
+
+    indices = jnp.sort(indices)
+
+    return jnp.array(indices)
+
+def project_slice_batch(vb_batch, n_p, n_pc):
+    """Inner kernel: scatter-add for one slice batch (_B slices)."""
+    sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+    for no in (-1, 0, 1):
+        n     = n_pc + no
+        abs_d = jnp.abs(n_p - n)
+        L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+        A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+        sb    = sb.at[:, n].add(A * vb_batch)
+    return sb
+
+
+def forward_ref(voxel, n_p, n_pc):
+    """REFERENCE: a single big scatter, no scan / no lax.map."""
+    sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+    for no in (-1, 0, 1):
+        n     = n_pc + no
+        abs_d = jnp.abs(n_p - n)
+        L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+        A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+        sino  = sino.at[:, n].add(A * voxel.T)
+    return sino
+
+
+def forward_buggy(voxel, n_p, n_pc):
+    """BUGGY: lax.map over _NB slice batches."""
+    vb_batched = voxel.T.reshape(_NB, _B, NP)
+    def body(vb):
+        return project_slice_batch(vb, n_p, n_pc)
+    return jax.lax.map(body, vb_batched).reshape(N_ROWS, ND)
+
+
+def compare(name, voxel, n_p, n_pc, use_vmap_axis=None):
+    """Run both paths and report max|diff|.  If use_vmap_axis is set,
+    add a vmap over that axis of n_p / n_pc / voxel."""
+    if use_vmap_axis is None:
+        ref_fn   = jax.jit(forward_ref)
+        buggy_fn = jax.jit(forward_buggy)
+        ref   = ref_fn(voxel, n_p, n_pc)
+        buggy = buggy_fn(voxel, n_p, n_pc)
+    else:
+        ref_fn   = jax.jit(jax.vmap(forward_ref,   in_axes=(None, 0, 0)))
+        buggy_fn = jax.jit(jax.vmap(forward_buggy, in_axes=(None, 0, 0)))
+        ref   = ref_fn(voxel, n_p, n_pc)
+        buggy = buggy_fn(voxel, n_p, n_pc)
+    diff = jnp.abs(ref - buggy)
+    md   = float(diff.max())
+    # Report worst (slice, channel) for context
+    if md > 1e-3:
+        idx = jnp.unravel_index(jnp.argmax(diff), diff.shape)
+        idx_t = tuple(int(i) for i in idx)
+        tag = "✗ BUG"
+    else:
+        idx_t = None
+        tag = "✓ ok "
+    print(f"  {name:<60s}  max|diff| = {md:.4e}  {tag}"
+          + (f"  at {idx_t}" if idx_t else ""))
+    return md
+
+
+# Common voxel data (kept the same across all tests for fair comparison)
+np.random.seed(0)
+voxel_np = np.random.rand(NP, N_ROWS).astype(np.float32)
+voxel    = jnp.array(voxel_np)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print("─" * 70)
+print("T1: ONE half-integer pixel (n_p[0] = 171.5), rest random")
+print("─" * 70)
+
+n_p_np = np.random.uniform(1, ND - 2, NP).astype(np.float32)
+n_p_np[0] = np.float32(171.5)
+n_pc_np = np.round(n_p_np).astype(np.int32)
+# sanity: float32(171.5) rounds to 172 (banker's)
+assert n_pc_np[0] == 172, f"n_pc[0]={n_pc_np[0]}, expected 172"
+compare("T1  no vmap   ", voxel, jnp.array(n_p_np), jnp.array(n_pc_np))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T2: ALL n_p exactly at half-integers, n_pc = banker's round")
+print("─" * 70)
+
+# Spread half-integer n_p values across the valid channel range
+half = np.arange(NP) % (ND - 4) + 2          # integer channels 2..ND-3
+n_p_np = (half + 0.5).astype(np.float32)     # all .5 values
+n_pc_np = np.round(n_p_np).astype(np.int32)  # banker's rounding
+compare("T2  no vmap   ", voxel, jnp.array(n_p_np), jnp.array(n_pc_np))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T3: T2 + jax.vmap over 2 'views' (different n_pc patterns)")
+print("─" * 70)
+
+half0 = np.arange(NP) % (ND - 4) + 2
+half1 = (np.arange(NP) + 7) % (ND - 4) + 2
+n_p_np  = np.stack([(half0 + 0.5), (half1 + 0.5)]).astype(np.float32)
+n_pc_np = np.round(n_p_np).astype(np.int32)
+compare("T3  vmap-over-views", voxel,
+        jnp.array(n_p_np), jnp.array(n_pc_np), use_vmap_axis=0)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T4: many pixels collide on a single channel (production-like)")
+print("─" * 70)
+
+# All 2048 pixels point at channel 172 with n_p exactly 171.5.
+# This creates extreme duplicate-index pressure on the scatter.
+n_p_np  = np.full(NP, 171.5, dtype=np.float32)
+n_pc_np = np.round(n_p_np).astype(np.int32)
+assert n_pc_np[0] == 172
+compare("T4  all-collide", voxel, jnp.array(n_p_np), jnp.array(n_pc_np))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T4b: same as T4 but with +1e-3 perturbation (should be clean)")
+print("─" * 70)
+
+n_p_np = np.full(NP, 171.5 + 1e-3, dtype=np.float32)
+n_pc_np = np.round(n_p_np).astype(np.int32)
+compare("T4b perturbed  ", voxel, jnp.array(n_p_np), jnp.array(n_pc_np))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T5: production-style n_p from cos/sin of integer pixel grid (no mbirjax)")
+print("─" * 70)
+
+# Build a 2D integer pixel grid (32x64 = 2048 pixels), centered.
+ROWS, COLS = 32, 64
+assert ROWS * COLS == NP
+ri, ci = np.meshgrid(np.arange(ROWS), np.arange(COLS), indexing='ij')
+yt = (ri.ravel() - (ROWS - 1) / 2.0).astype(np.float32)
+xt = (ci.ravel() - (COLS - 1) / 2.0).astype(np.float32)
+DCC = (ND - 1) / 2.0           # = 127.5
+OFF = np.float32(0.0)
+DDC = np.float32(1.0)
+
+# Try several angles; report each.  View 12 of 180 = 12*π/180.
+for view_idx in (12, 134, 45, 90):
+    angle = np.float32(view_idx * np.pi / 180.0)
+    ct = np.cos(angle).astype(np.float32)
+    st = np.sin(angle).astype(np.float32)
+    x_p = ct * xt - st * yt
+    n_p_np  = ((x_p + OFF) / DDC + DCC).astype(np.float32)
+    n_pc_np = np.round(n_p_np).astype(np.int32)
+    n_half  = int(np.sum(np.abs(n_p_np - np.round(n_p_np)) < 1e-5))
+    label = f"T5  view={view_idx:>3d}  half-integer n_p count={n_half:>3d}"
+    compare(label, voxel, jnp.array(n_p_np), jnp.array(n_pc_np))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T6: T5 + vmap over both 'bad views' simultaneously (matches demo shape)")
+print("─" * 70)
+
+n_p_list, n_pc_list = [], []
+for view_idx in (12, 134):
+    angle = np.float32(view_idx * np.pi / 180.0)
+    ct = np.cos(angle).astype(np.float32)
+    st = np.sin(angle).astype(np.float32)
+    x_p = ct * xt - st * yt
+    n_p_np  = ((x_p + OFF) / DDC + DCC).astype(np.float32)
+    n_pc_np = np.round(n_p_np).astype(np.int32)
+    n_p_list.append(n_p_np)
+    n_pc_list.append(n_pc_np)
+n_p_2v  = jnp.array(np.stack(n_p_list))
+n_pc_2v = jnp.array(np.stack(n_pc_list))
+compare("T6  vmap over 2 views", voxel, n_p_2v, n_pc_2v, use_vmap_axis=0)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T7: circular ROR mask (mimics mbirjax use_ror_mask=True default)")
+print("─" * 70)
+
+# Default mbirjax recon_shape for (N_VIEWS, N_ROWS, N_CHANNELS=256) is
+# typically (256, 256, 128).  pixels are (row, col) indexed.  ROR keeps only
+# the disc inscribed in the rectangular grid.
+ROWS_3D, COLS_3D = 256, 256
+i_grid, j_grid = np.meshgrid(np.arange(ROWS_3D), np.arange(COLS_3D), indexing='ij')
+yc = (ROWS_3D - 1) / 2.0
+xc = (COLS_3D - 1) / 2.0
+r_sq = (i_grid - yc) ** 2 + (j_grid - xc) ** 2
+mask = r_sq <= (min(ROWS_3D, COLS_3D) / 2.0) ** 2
+in_ror_flat = np.where(mask.ravel())[0]
+print(f"  In-ROR pixels: {len(in_ror_flat)} / {ROWS_3D * COLS_3D}  "
+      f"({100.0 * len(in_ror_flat) / (ROWS_3D * COLS_3D):.1f}%)")
+
+# Batch 8 (BAD=8 in demo), 2048 pixels
+BAD = 8
+assert (BAD + 1) * NP <= len(in_ror_flat), "ROR doesn't have enough pixels for batch 8"
+pb = in_ror_flat[BAD * NP : (BAD + 1) * NP]
+ri_np, ci_np = np.unravel_index(pb, (ROWS_3D, COLS_3D))
+yt_ror = (1.0 * (ri_np - (ROWS_3D - 1) / 2.0)).astype(np.float32)
+xt_ror = (1.0 * (ci_np - (COLS_3D - 1) / 2.0)).astype(np.float32)
+print(f"  Batch {BAD}: row range = {ri_np.min()}..{ri_np.max()}, "
+      f"col range = {ci_np.min()}..{ci_np.max()}")
+
+DCC_p = (ND - 1) / 2.0     # = 127.5
+
+for view_idx in (12, 134):
+    angle = np.float32(view_idx * np.pi / 180.0)
+    ct = np.cos(angle).astype(np.float32)
+    st = np.sin(angle).astype(np.float32)
+    x_p = ct * xt_ror - st * yt_ror
+    n_p_np  = ((x_p + 0.0) / 1.0 + DCC_p).astype(np.float32)
+    n_pc_np = np.round(n_p_np).astype(np.int32)
+
+    # How many n_p land exactly on half-integers?  And what's the closest
+    # any pixel gets?
+    frac     = np.abs(n_p_np - np.round(n_p_np))
+    n_half   = int(np.sum(frac < 1e-6))
+    closest  = float(np.min(np.abs(frac - 0.5)))   # distance to nearest .5
+    # Also: any n_p exactly = X.5?
+    diff_5   = np.abs(n_p_np - (np.floor(n_p_np) + 0.5))
+    n_exact5 = int(np.sum(diff_5 < 1e-6))
+
+    label = (f"T7  ROR view={view_idx:>3d}  exact-half-int n_p={n_exact5:>3d}  "
+             f"closest-to-.5={closest:.2e}")
+    compare(label, voxel, jnp.array(n_p_np), jnp.array(n_pc_np))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T8: production (xt, yt) from local gen_pixel_partition  (mbirjax-free)")
+print("─" * 70)
+
+# Hardcoded defaults matching mbirjax ParallelBeamModel((180, 128, 256)).
+# DV/DDC/OFF are the parallel-beam defaults (1.0, 1.0, 0.0).  recon_shape
+# is (cols, rows, slices) = (256, 256, 128).  use_ror_mask=True is the
+# critical ingredient — toggling it to False makes the bug vanish in the demo.
+N_VIEWS = 180
+angles_full = np.linspace(0, np.pi, N_VIEWS, endpoint=False)
+recon_shape = (256, 256, 128)
+DV_prod  = 1.0
+DDC_prod = 1.0
+OFF_prod = 0.0
+DCC_prod = (ND - 1) / 2.0
+print(f"  recon_shape = {recon_shape}")
+
+all_indices = np.asarray(gen_pixel_partition(recon_shape, use_ror_mask=True))
+print(f"  total in-ROR pixels: {len(all_indices)} "
+      f"(rectangular would be {recon_shape[0] * recon_shape[1]})")
+
+# Production demo's BAD = 8, PBSZ = NP = 2048
+BAD = 8
+pb_prod = all_indices[BAD * NP : (BAD + 1) * NP]
+ri_p, ci_p = np.unravel_index(pb_prod, recon_shape[:2])
+yt_prod = (DV_prod * (ri_p - (recon_shape[0] - 1) / 2.0)).astype(np.float32)
+xt_prod = (DV_prod * (ci_p - (recon_shape[1] - 1) / 2.0)).astype(np.float32)
+print(f"  Batch {BAD}: row range = {ri_p.min()}..{ri_p.max()}, "
+      f"col range = {ci_p.min()}..{ci_p.max()}")
+
+# Compute n_p / n_pc / W_pc / cos_a per view using *production* geometry params
+def prod_geom(view_idx):
+    angle = np.float32(angles_full[view_idx])
+    ct = np.cos(angle).astype(np.float32)
+    st = np.sin(angle).astype(np.float32)
+    x_p = ct * xt_prod - st * yt_prod
+    n_p_ = ((x_p + OFF_prod) / DDC_prod + DCC_prod).astype(np.float32)
+    n_pc_ = np.round(n_p_).astype(np.int32)
+    cos_a_ = np.float32(max(abs(ct), abs(st)))
+    W_pc_ = np.float32((DV_prod / DDC_prod) * cos_a_)
+    L_mx_ = np.float32(min(1.0, float(W_pc_)))
+    return n_p_, n_pc_, W_pc_, cos_a_, L_mx_
+
+# We need per-view W_pc/cos_a/L_mx now, so compare() in its current form
+# (which uses module-level constants) won't work.  Define a local variant.
+def compare_per_view(view_idx):
+    n_p_np, n_pc_np, W_v, cos_v, L_v = prod_geom(view_idx)
+    n_half = int(np.sum(np.abs(n_p_np - np.round(n_p_np)) < 1e-6))
+
+    def fwd_ref(voxel_, n_p_, n_pc_):
+        sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+        for no in (-1, 0, 1):
+            n     = n_pc_ + no
+            abs_d = jnp.abs(n_p_ - n)
+            L     = jnp.clip((W_v + 1.0) / 2.0 - abs_d, 0.0, L_v)
+            A     = DV_prod * L / cos_v * ((n >= 0) & (n < ND))
+            sino  = sino.at[:, n].add(A * voxel_.T)
+        return sino
+
+    def fwd_buggy(voxel_, n_p_, n_pc_):
+        vb_batched = voxel_.T.reshape(_NB, _B, NP)
+        def body(vb):
+            sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+            for no in (-1, 0, 1):
+                n     = n_pc_ + no
+                abs_d = jnp.abs(n_p_ - n)
+                L     = jnp.clip((W_v + 1.0) / 2.0 - abs_d, 0.0, L_v)
+                A     = DV_prod * L / cos_v * ((n >= 0) & (n < ND))
+                sb    = sb.at[:, n].add(A * vb)
+            return sb
+        return jax.lax.map(body, vb_batched).reshape(N_ROWS, ND)
+
+    n_p_j  = jnp.array(n_p_np)
+    n_pc_j = jnp.array(n_pc_np)
+    ref   = jax.jit(fwd_ref)(voxel, n_p_j, n_pc_j)
+    buggy = jax.jit(fwd_buggy)(voxel, n_p_j, n_pc_j)
+    diff = jnp.abs(ref - buggy)
+    md   = float(diff.max())
+    tag  = "✗ BUG" if md > 1e-3 else "✓ ok "
+    print(f"  T8  prod-geom view={view_idx:>3d}  exact-half-int n_p={n_half:>3d}  "
+          f"W={float(W_v):.4f}  max|diff|={md:.4e}  {tag}")
+
+for view_idx in (12, 134, 0, 45, 90):
+    compare_per_view(view_idx)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T9: production geom + n_p derived in-jit from angle (mirrors demo)")
+print("─" * 70)
+
+xt_jnp = jnp.array(xt_prod)
+yt_jnp = jnp.array(yt_prod)
+
+def _geom_inline(angle):
+    """Replicates the demo's _geom — n_p, n_pc derived inside the jit."""
+    ct = jnp.cos(angle)
+    st = jnp.sin(angle)
+    x_p   = ct * xt_jnp - st * yt_jnp
+    n_p   = (x_p + OFF_prod) / DDC_prod + DCC_prod
+    n_pc  = jnp.round(n_p).astype(jnp.int32)
+    cos_a = jnp.maximum(jnp.abs(ct), jnp.abs(st))
+    W_pc  = (DV_prod / DDC_prod) * cos_a
+    L_mx  = jnp.minimum(1.0, W_pc)
+    return n_p, n_pc, W_pc, cos_a, L_mx
+
+
+def forward_ref_inline(angle):
+    n_p, n_pc, W_pc, cos_a, L_mx = _geom_inline(angle)
+    sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+    for no in (-1, 0, 1):
+        n     = n_pc + no
+        abs_d = jnp.abs(n_p - n)
+        L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+        A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+        sino  = sino.at[:, n].add(A * voxel.T)
+    return sino
+
+
+def forward_buggy_inline(angle):
+    n_p, n_pc, W_pc, cos_a, L_mx = _geom_inline(angle)
+    vb_batched = voxel.T.reshape(_NB, _B, NP)
+    def body(vb):
+        sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+        for no in (-1, 0, 1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+            A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+            sb    = sb.at[:, n].add(A * vb)
+        return sb
+    return jax.lax.map(body, vb_batched).reshape(N_ROWS, ND)
+
+
+angles_2v = jnp.array(angles_full[[12, 134]].astype(np.float32))
+
+# T9a: vmap over the 2 bad views (matches demo exactly)
+ref_v   = jax.jit(jax.vmap(forward_ref_inline))(angles_2v)
+buggy_v = jax.jit(jax.vmap(forward_buggy_inline))(angles_2v)
+diff_v  = jnp.abs(ref_v - buggy_v)
+md_v    = float(diff_v.max())
+print(f"  T9a  vmap+in-jit  views=[12,134]   max|diff| = {md_v:.4e}   "
+      f"{'✗ BUG' if md_v > 1e-3 else '✓ ok '}")
+
+# T9b: in-jit n_p, single view at a time (no vmap)
+for view_idx in (12, 134):
+    a = jnp.array(np.float32(angles_full[view_idx]))
+    ref_s   = jax.jit(forward_ref_inline)(a)
+    buggy_s = jax.jit(forward_buggy_inline)(a)
+    md_s    = float(jnp.abs(ref_s - buggy_s).max())
+    print(f"  T9b  in-jit no-vmap  view={view_idx:>3d}      max|diff| = {md_s:.4e}   "
+          f"{'✗ BUG' if md_s > 1e-3 else '✓ ok '}")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T10–T13: minimize the T9a reproducer along several axes")
+print("─" * 70)
+
+# Reusable factory: build forward_ref / forward_buggy bound to a given
+# (xt, yt) pixel set, then vmap over a chosen set of angles.
+def make_pair(xt_np, yt_np):
+    """Return (jitted_ref_vmap, jitted_buggy_vmap, voxel) functions
+    parameterized by an angles tensor."""
+    xt_j = jnp.array(xt_np.astype(np.float32))
+    yt_j = jnp.array(yt_np.astype(np.float32))
+    NP_local = xt_j.shape[0]
+    # voxel shape must match the inner kernel
+    np.random.seed(0)
+    vox = jnp.array(np.random.rand(NP_local, N_ROWS).astype(np.float32))
+
+    def geom(angle):
+        ct = jnp.cos(angle); st = jnp.sin(angle)
+        x_p   = ct * xt_j - st * yt_j
+        n_p   = (x_p + OFF_prod) / DDC_prod + DCC_prod
+        n_pc  = jnp.round(n_p).astype(jnp.int32)
+        cos_a = jnp.maximum(jnp.abs(ct), jnp.abs(st))
+        W_pc  = (DV_prod / DDC_prod) * cos_a
+        L_mx  = jnp.minimum(1.0, W_pc)
+        return n_p, n_pc, W_pc, cos_a, L_mx
+
+    def fwd_ref(angle):
+        n_p, n_pc, W_pc, cos_a, L_mx = geom(angle)
+        sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+        for no in (-1, 0, 1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+            A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+            sino  = sino.at[:, n].add(A * vox.T)
+        return sino
+
+    def fwd_buggy(angle):
+        n_p, n_pc, W_pc, cos_a, L_mx = geom(angle)
+        vb_batched = vox.T.reshape(_NB, _B, NP_local)
+        def body(vb):
+            sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+            for no in (-1, 0, 1):
+                n     = n_pc + no
+                abs_d = jnp.abs(n_p - n)
+                L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+                A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+                sb    = sb.at[:, n].add(A * vb)
+            return sb
+        return jax.lax.map(body, vb_batched).reshape(N_ROWS, ND)
+
+    return fwd_ref, fwd_buggy
+
+
+def run_vmap(label, xt_np, yt_np, view_indices):
+    fr, fb = make_pair(xt_np, yt_np)
+    angs = jnp.array(angles_full[list(view_indices)].astype(np.float32))
+    ref_v   = jax.jit(jax.vmap(fr))(angs)
+    buggy_v = jax.jit(jax.vmap(fb))(angs)
+    md = float(jnp.abs(ref_v - buggy_v).max())
+    tag = "✗ BUG" if md > 1e-3 else "✓ ok "
+    print(f"  {label:<60s}  max|diff|={md:.4e}  {tag}")
+    return md
+
+# T10 — sanity: use_ror_mask=False with vmap (should NOT bug)
+ridx_off = np.asarray(gen_pixel_partition(recon_shape, use_ror_mask=False))
+pb_off = ridx_off[BAD * NP : (BAD + 1) * NP]
+ri_off, ci_off = np.unravel_index(pb_off, recon_shape[:2])
+yt_off = DV_prod * (ri_off - (recon_shape[0] - 1) / 2.0)
+xt_off = DV_prod * (ci_off - (recon_shape[1] - 1) / 2.0)
+run_vmap("T10 ROR=False  vmap[12,134]   (sanity — should be clean)",
+         xt_off, yt_off, (12, 134))
+
+# T11 — does the vmap need both views, or is one enough?
+run_vmap("T11a ROR=True  vmap[12]        (single view in vmap)",
+         xt_prod, yt_prod, (12,))
+run_vmap("T11b ROR=True  vmap[134]       (single view in vmap)",
+         xt_prod, yt_prod, (134,))
+
+# T12 — pair view 12 with an irrelevant view; does it still trigger?
+run_vmap("T12a ROR=True  vmap[12, 0]    (12 + a clean view)",
+         xt_prod, yt_prod, (12, 0))
+run_vmap("T12b ROR=True  vmap[12, 12]   (12 paired with itself)",
+         xt_prod, yt_prod, (12, 12))
+
+# T13 — smaller recon (still ROR-masked), batch 0 (always exists).
+for rs in [(128, 128, 128), (64, 64, 128), (32, 32, 128)]:
+    idx_small = np.asarray(gen_pixel_partition(rs, use_ror_mask=True))
+    if NP > len(idx_small):
+        print(f"  T13  recon={rs}  -- can't even fit one batch of {NP} -- SKIP")
+        continue
+    pb_s = idx_small[0:NP]
+    ri_s, ci_s = np.unravel_index(pb_s, rs[:2])
+    yt_s = DV_prod * (ri_s - (rs[0] - 1) / 2.0)
+    xt_s = DV_prod * (ci_s - (rs[1] - 1) / 2.0)
+    run_vmap(f"T13 ROR=True  recon={rs}  vmap[12]  BAD=0",
+             xt_s, yt_s, (12,))
+
+# T14 — scan BAD over 256×256 ROR to see which batches fire.
+print()
+print("  T14: BAD scan on 256×256 ROR  (which pixel batches trigger?)")
+n_total_batches = len(all_indices) // NP
+for B in range(0, n_total_batches):
+    pb_b = all_indices[B * NP : (B + 1) * NP]
+    ri_b, ci_b = np.unravel_index(pb_b, recon_shape[:2])
+    yt_b = DV_prod * (ri_b - (recon_shape[0] - 1) / 2.0)
+    xt_b = DV_prod * (ci_b - (recon_shape[1] - 1) / 2.0)
+    fr, fb = make_pair(xt_b, yt_b)
+    a = jnp.array(angles_full[[12]].astype(np.float32))
+    ref_v   = jax.jit(jax.vmap(fr))(a)
+    buggy_v = jax.jit(jax.vmap(fb))(a)
+    md = float(jnp.abs(ref_v - buggy_v).max())
+    tag = "✗ BUG" if md > 1e-3 else "✓ ok "
+    print(f"    BAD={B:>2d}  rows={ri_b.min():>3d}..{ri_b.max():>3d}  "
+          f"max|diff|={md:.4e}  {tag}")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T15: does safe_round() perturbation kill the bug?")
+print("─" * 70)
+print()
+print("  safe_round(x, scale=1e-4):")
+print("    snapped = round(x / scale) * scale     # snap to 1e-4 grid")
+print("    return  round(snapped + 0.5*scale)     # nudge past half-integer")
+print()
+
+
+def safe_round(x, scale=1e-4):
+    """Round x to int32, robust to last-bit-different recomputations of x.
+
+    The first round snaps any x that lives within scale/2 of a 1e-4 grid
+    point to that grid point.  Two upstream chains that compute x to
+    last-bit-different float values both land on the same grid point.
+    The +0.5*scale nudge then guarantees the final round() never sees an
+    exact half-integer tie, so its result is independent of any CSE-
+    duplicate chain's floating-point ordering.
+    """
+    snapped = jnp.round(x / scale) * scale
+    return jnp.round(snapped + 0.5 * scale).astype(jnp.int32)
+
+
+def make_pair_safe(xt_np, yt_np):
+    """Same as make_pair, but uses safe_round in place of jnp.round for n_pc."""
+    xt_j = jnp.array(xt_np.astype(np.float32))
+    yt_j = jnp.array(yt_np.astype(np.float32))
+    NP_local = xt_j.shape[0]
+    np.random.seed(0)
+    vox = jnp.array(np.random.rand(NP_local, N_ROWS).astype(np.float32))
+
+    def geom(angle):
+        ct = jnp.cos(angle); st = jnp.sin(angle)
+        x_p   = ct * xt_j - st * yt_j
+        n_p   = (x_p + OFF_prod) / DDC_prod + DCC_prod
+        n_pc  = safe_round(n_p)                  # ← only change vs make_pair
+        cos_a = jnp.maximum(jnp.abs(ct), jnp.abs(st))
+        W_pc  = (DV_prod / DDC_prod) * cos_a
+        L_mx  = jnp.minimum(1.0, W_pc)
+        return n_p, n_pc, W_pc, cos_a, L_mx
+
+    def fwd_ref(angle):
+        n_p, n_pc, W_pc, cos_a, L_mx = geom(angle)
+        sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+        for no in (-1, 0, 1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+            A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+            sino  = sino.at[:, n].add(A * vox.T)
+        return sino
+
+    def fwd_buggy(angle):
+        n_p, n_pc, W_pc, cos_a, L_mx = geom(angle)
+        vb_batched = vox.T.reshape(_NB, _B, NP_local)
+        def body(vb):
+            sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+            for no in (-1, 0, 1):
+                n     = n_pc + no
+                abs_d = jnp.abs(n_p - n)
+                L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+                A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+                sb    = sb.at[:, n].add(A * vb)
+            return sb
+        return jax.lax.map(body, vb_batched).reshape(N_ROWS, ND)
+
+    return fwd_ref, fwd_buggy
+
+
+# T15a — does safe_round fix the original bug config (BAD=8, vmap[12])?
+pb_8 = all_indices[8 * NP : 9 * NP]
+ri_8, ci_8 = np.unravel_index(pb_8, recon_shape[:2])
+yt_8 = DV_prod * (ri_8 - (recon_shape[0] - 1) / 2.0)
+xt_8 = DV_prod * (ci_8 - (recon_shape[1] - 1) / 2.0)
+fr_safe, fb_safe  = make_pair_safe(xt_8, yt_8)
+fr_van,  fb_van   = make_pair(xt_8, yt_8)
+a12 = jnp.array(angles_full[[12]].astype(np.float32))
+
+# Baseline: confirm the bug is present without safe_round
+ref_van   = jax.jit(jax.vmap(fr_van))(a12)
+buggy_van = jax.jit(jax.vmap(fb_van))(a12)
+md_van = float(jnp.abs(ref_van - buggy_van).max())
+
+# With safe_round
+ref_safe   = jax.jit(jax.vmap(fr_safe))(a12)
+buggy_safe = jax.jit(jax.vmap(fb_safe))(a12)
+md_safe = float(jnp.abs(ref_safe - buggy_safe).max())
+
+print(f"  T15a  BAD=8  vmap[12]")
+print(f"        vanilla round:  max|diff|(buggy vs ref) = {md_van:.4e}  "
+      f"{'✗ BUG' if md_van > 1e-3 else '✓ ok '}  (expected: BUG)")
+print(f"        safe_round:     max|diff|(buggy vs ref) = {md_safe:.4e}  "
+      f"{'✗ BUG' if md_safe > 1e-3 else '✓ ok '}  (expected: ok)")
+
+# How different is safe_round's reference from vanilla round's reference?
+# (Only tie-pixels should differ; everywhere else float-noise.)
+md_refdiff = float(jnp.abs(ref_safe - ref_van).max())
+print(f"        ref_safe vs ref_vanilla:  max|diff| = {md_refdiff:.4e}  "
+      f"(non-tie pixels agree; small diff expected at any tie sites)")
+
+# T15b — BAD scan with safe_round (mirrors T14 but with the fix applied)
+print()
+print("  T15b: BAD scan with safe_round (expect all ✓ ok)")
+n_bug_safe = 0
+worst_safe = 0.0
+for B in range(0, n_total_batches):
+    pb_b = all_indices[B * NP : (B + 1) * NP]
+    ri_b, ci_b = np.unravel_index(pb_b, recon_shape[:2])
+    yt_b = DV_prod * (ri_b - (recon_shape[0] - 1) / 2.0)
+    xt_b = DV_prod * (ci_b - (recon_shape[1] - 1) / 2.0)
+    fr, fb = make_pair_safe(xt_b, yt_b)
+    a = jnp.array(angles_full[[12]].astype(np.float32))
+    ref_v   = jax.jit(jax.vmap(fr))(a)
+    buggy_v = jax.jit(jax.vmap(fb))(a)
+    md = float(jnp.abs(ref_v - buggy_v).max())
+    worst_safe = max(worst_safe, md)
+    if md > 1e-3:
+        n_bug_safe += 1
+        print(f"    BAD={B:>2d}  max|diff|={md:.4e}  ✗ BUG")
+print(f"  → with safe_round: {n_bug_safe} of {n_total_batches} batches bug "
+      f"(was 1 with vanilla round, see T14).  worst max|diff| = {worst_safe:.4e}")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+print()
+print("─" * 70)
+print("T15c–e: alternative round-function fixes — does any kill the bug everywhere?")
+print("─" * 70)
+
+
+def make_pair_with_round(xt_np, yt_np, round_fn):
+    """Parametric: replace jnp.round in geom with `round_fn`."""
+    xt_j = jnp.array(xt_np.astype(np.float32))
+    yt_j = jnp.array(yt_np.astype(np.float32))
+    NP_local = xt_j.shape[0]
+    np.random.seed(0)
+    vox = jnp.array(np.random.rand(NP_local, N_ROWS).astype(np.float32))
+
+    def geom(angle):
+        ct = jnp.cos(angle); st = jnp.sin(angle)
+        x_p   = ct * xt_j - st * yt_j
+        n_p   = (x_p + OFF_prod) / DDC_prod + DCC_prod
+        n_pc  = round_fn(n_p)
+        cos_a = jnp.maximum(jnp.abs(ct), jnp.abs(st))
+        W_pc  = (DV_prod / DDC_prod) * cos_a
+        L_mx  = jnp.minimum(1.0, W_pc)
+        return n_p, n_pc, W_pc, cos_a, L_mx
+
+    def fwd_ref(angle):
+        n_p, n_pc, W_pc, cos_a, L_mx = geom(angle)
+        sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+        for no in (-1, 0, 1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+            A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+            sino  = sino.at[:, n].add(A * vox.T)
+        return sino
+
+    def fwd_buggy(angle):
+        n_p, n_pc, W_pc, cos_a, L_mx = geom(angle)
+        vb_batched = vox.T.reshape(_NB, _B, NP_local)
+        def body(vb):
+            sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+            for no in (-1, 0, 1):
+                n     = n_pc + no
+                abs_d = jnp.abs(n_p - n)
+                L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+                A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+                sb    = sb.at[:, n].add(A * vb)
+            return sb
+        return jax.lax.map(body, vb_batched).reshape(N_ROWS, ND)
+
+    return fwd_ref, fwd_buggy
+
+
+def bad_scan_with(round_fn, label):
+    """Sweep BAD = 0..23 with the given round_fn, report any bugs."""
+    bad = []
+    worst = 0.0
+    for B in range(0, n_total_batches):
+        pb_b = all_indices[B * NP : (B + 1) * NP]
+        ri_b, ci_b = np.unravel_index(pb_b, recon_shape[:2])
+        yt_b = DV_prod * (ri_b - (recon_shape[0] - 1) / 2.0)
+        xt_b = DV_prod * (ci_b - (recon_shape[1] - 1) / 2.0)
+        fr, fb = make_pair_with_round(xt_b, yt_b, round_fn)
+        a = jnp.array(angles_full[[12]].astype(np.float32))
+        ref_v   = jax.jit(jax.vmap(fr))(a)
+        buggy_v = jax.jit(jax.vmap(fb))(a)
+        md = float(jnp.abs(ref_v - buggy_v).max())
+        worst = max(worst, md)
+        if md > 1e-3:
+            bad.append((B, md))
+    if not bad:
+        print(f"  {label:<55s}  ✓ all 24 batches clean (worst {worst:.2e})")
+    else:
+        details = ", ".join(f"BAD={B}({md:.3e})" for B, md in bad)
+        print(f"  {label:<55s}  ✗ {len(bad)} bad: {details}")
+    return len(bad), worst
+
+
+# ── Define variants ──────────────────────────────────────────────────────
+
+# Baseline (no fix): vanilla jnp.round
+def round_vanilla(x):
+    return jnp.round(x).astype(jnp.int32)
+
+# T15c: smaller scale safe_round.  At scale 1e-6, x / scale is ≈ 1.7e8;
+# float32 ULP at that magnitude (~16) is so much larger than 0.5 that the
+# first-round tie set is unrepresentable, so the first round can't break
+# ties inconsistently.  The quantization step then rounds to ~16-unit grid
+# (effectively a no-op for the scale-1e-6 perturbation), but the +0.5e-6
+# offset is still the perturbation that pushes past the FINAL round's tie.
+def round_safe_1e6(x):
+    scale = 1e-6
+    snapped = jnp.round(x / scale) * scale
+    return jnp.round(snapped + 0.5 * scale).astype(jnp.int32)
+
+# T15d: optimization_barrier alone — addresses the (hypothesized) root cause
+# directly by preventing XLA from CSE-duplicating the round computation.
+def round_barrier(x):
+    n_pc = jnp.round(x).astype(jnp.int32)
+    return jax.lax.optimization_barrier(n_pc)
+
+# T15e: safe_round (1e-4) + optimization_barrier — belt and suspenders.
+def round_safe_plus_barrier(x):
+    scale = 1e-4
+    snapped = jnp.round(x / scale) * scale
+    n_pc = jnp.round(snapped + 0.5 * scale).astype(jnp.int32)
+    return jax.lax.optimization_barrier(n_pc)
+
+
+# ── Run all variants over the 24-batch scan ──────────────────────────────
+print()
+print("  (worst max|diff| over all 24 batches; 'clean' threshold = 1e-3)")
+print()
+bad_scan_with(round_vanilla,           "T14 (vanilla, baseline)")
+bad_scan_with(safe_round,              "T15a/b (safe_round, scale=1e-4)")
+bad_scan_with(round_safe_1e6,          "T15c (safe_round, scale=1e-6)")
+bad_scan_with(round_barrier,           "T15d (jnp.round + optimization_barrier)")
+bad_scan_with(round_safe_plus_barrier, "T15e (safe_round + optimization_barrier)")
+
+
+# T15f: safe_round in float64.  Idea: cast to float64 internally, so the
+# arithmetic inside safe_round has ~16 digits of precision instead of ~7.
+# This won't add information to a float32 input (the value is the same after
+# cast) but it lets the snap-and-perturb steps avoid the float32 ULP issues
+# that turned T15c into a no-op, and it spreads any tie-condition on a
+# much finer grid.
+def round_safe_f64(scale):
+    def _r(x):
+        x64 = x.astype(jnp.float64)
+        snapped = jnp.round(x64 / scale) * scale
+        return jnp.round(snapped + 0.5 * scale).astype(jnp.int32)
+    return _r
+
+
+# Cast n_p input to float64 then do safe_round at three scales.
+bad_scan_with(round_safe_f64(1e-4),    "T15f safe_round_f64 (scale=1e-4)")
+bad_scan_with(round_safe_f64(1e-6),    "T15g safe_round_f64 (scale=1e-6)")
+bad_scan_with(round_safe_f64(1e-8),    "T15h safe_round_f64 (scale=1e-8)")
+
+
+# ── T15i: precompute geometry outside the jit ────────────────────────────
+# If this is clean across all batches, the bug requires `round` to live
+# inside the vmap+lax.map boundary, and the fix is to precompute the
+# (n_p, n_pc, W_pc, cos_a, L_mx) tuple in numpy and pass it in.
+
+def make_pair_precomputed():
+    """fwd_ref / fwd_buggy that take precomputed geometry as JAX inputs.
+    No cos/sin/round inside.  Voxel data is local because NP depends on
+    the pixel batch."""
+    def make(NP_local):
+        np.random.seed(0)
+        vox = jnp.array(np.random.rand(NP_local, N_ROWS).astype(np.float32))
+
+        def fwd_ref(n_p, n_pc, W_pc, cos_a, L_mx):
+            sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+            for no in (-1, 0, 1):
+                n     = n_pc + no
+                abs_d = jnp.abs(n_p - n)
+                L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+                A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+                sino  = sino.at[:, n].add(A * vox.T)
+            return sino
+
+        def fwd_buggy(n_p, n_pc, W_pc, cos_a, L_mx):
+            vb_batched = vox.T.reshape(_NB, _B, NP_local)
+            def body(vb):
+                sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+                for no in (-1, 0, 1):
+                    n     = n_pc + no
+                    abs_d = jnp.abs(n_p - n)
+                    L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+                    A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+                    sb    = sb.at[:, n].add(A * vb)
+                return sb
+            return jax.lax.map(body, vb_batched).reshape(N_ROWS, ND)
+
+        return fwd_ref, fwd_buggy
+    return make
+
+def bad_scan_precomputed(label, view_idx=12):
+    """Like bad_scan_with but with all geometry computed in numpy and
+    passed in as JAX arrays."""
+    make = make_pair_precomputed()
+    bad, worst = [], 0.0
+    angle = np.float32(angles_full[view_idx])
+    ct = np.cos(angle).astype(np.float32)
+    st = np.sin(angle).astype(np.float32)
+    cos_a_np = np.float32(max(abs(ct), abs(st)))
+    W_pc_np  = np.float32((DV_prod / DDC_prod) * cos_a_np)
+    L_mx_np  = np.float32(min(1.0, float(W_pc_np)))
+    for B in range(0, n_total_batches):
+        pb_b = all_indices[B * NP : (B + 1) * NP]
+        ri_b, ci_b = np.unravel_index(pb_b, recon_shape[:2])
+        yt_b = (DV_prod * (ri_b - (recon_shape[0] - 1) / 2.0)).astype(np.float32)
+        xt_b = (DV_prod * (ci_b - (recon_shape[1] - 1) / 2.0)).astype(np.float32)
+        x_p_np  = ct * xt_b - st * yt_b
+        n_p_np  = ((x_p_np + OFF_prod) / DDC_prod + DCC_prod).astype(np.float32)
+        n_pc_np = np.round(n_p_np).astype(np.int32)
+        # Build vmap-batched inputs (size-1 vmap, mirroring T11a)
+        n_p_v  = jnp.array(n_p_np[None, :])
+        n_pc_v = jnp.array(n_pc_np[None, :])
+        W_v    = jnp.array(np.array([W_pc_np]))
+        ca_v   = jnp.array(np.array([cos_a_np]))
+        L_v    = jnp.array(np.array([L_mx_np]))
+
+        fr, fb = make(NP)
+        ref_v   = jax.jit(jax.vmap(fr))(n_p_v, n_pc_v, W_v, ca_v, L_v)
+        buggy_v = jax.jit(jax.vmap(fb))(n_p_v, n_pc_v, W_v, ca_v, L_v)
+        md = float(jnp.abs(ref_v - buggy_v).max())
+        worst = max(worst, md)
+        if md > 1e-3:
+            bad.append((B, md))
+    if not bad:
+        print(f"  {label:<55s}  ✓ all 24 batches clean (worst {worst:.2e})")
+    else:
+        details = ", ".join(f"BAD={B}({md:.3e})" for B, md in bad)
+        print(f"  {label:<55s}  ✗ {len(bad)} bad: {details}")
+
+bad_scan_precomputed("T15i precomputed geom (round outside the jit)")
+
+
+# ── T15j: precompute n_pc only, leave the rest of geom in-jit ────────────
+# This tests whether the minimal change is sufficient: keep cos/sin/n_p/
+# W_pc/cos_alpha/L_max derivation inside the jit (as in the current
+# production code), and only move the integer scatter index n_pc out.
+
+def make_pair_npc_only(xt_np, yt_np):
+    xt_j = jnp.array(xt_np.astype(np.float32))
+    yt_j = jnp.array(yt_np.astype(np.float32))
+    NP_local = xt_j.shape[0]
+    np.random.seed(0)
+    vox = jnp.array(np.random.rand(NP_local, N_ROWS).astype(np.float32))
+
+    def _geom_inline_no_round(angle):
+        """Same as _geom_inline but n_pc is NOT computed here."""
+        ct = jnp.cos(angle); st = jnp.sin(angle)
+        x_p   = ct * xt_j - st * yt_j
+        n_p   = (x_p + OFF_prod) / DDC_prod + DCC_prod
+        cos_a = jnp.maximum(jnp.abs(ct), jnp.abs(st))
+        W_pc  = (DV_prod / DDC_prod) * cos_a
+        L_mx  = jnp.minimum(1.0, W_pc)
+        return n_p, W_pc, cos_a, L_mx
+
+    def fwd_ref(angle, n_pc):
+        n_p, W_pc, cos_a, L_mx = _geom_inline_no_round(angle)
+        sino = jnp.zeros((N_ROWS, ND), dtype=jnp.float32)
+        for no in (-1, 0, 1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+            A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+            sino  = sino.at[:, n].add(A * vox.T)
+        return sino
+
+    def fwd_buggy(angle, n_pc):
+        n_p, W_pc, cos_a, L_mx = _geom_inline_no_round(angle)
+        vb_batched = vox.T.reshape(_NB, _B, NP_local)
+        def body(vb):
+            sb = jnp.zeros((_B, ND), dtype=jnp.float32)
+            for no in (-1, 0, 1):
+                n     = n_pc + no
+                abs_d = jnp.abs(n_p - n)
+                L     = jnp.clip((W_pc + 1.0) / 2.0 - abs_d, 0.0, L_mx)
+                A     = DV_prod * L / cos_a * ((n >= 0) & (n < ND))
+                sb    = sb.at[:, n].add(A * vb)
+            return sb
+        return jax.lax.map(body, vb_batched).reshape(N_ROWS, ND)
+
+    return fwd_ref, fwd_buggy
+
+
+def bad_scan_npc_only(label, view_idx=12):
+    bad, worst = [], 0.0
+    angle = np.float32(angles_full[view_idx])
+    ct = np.cos(angle).astype(np.float32)
+    st = np.sin(angle).astype(np.float32)
+    for B in range(0, n_total_batches):
+        pb_b = all_indices[B * NP : (B + 1) * NP]
+        ri_b, ci_b = np.unravel_index(pb_b, recon_shape[:2])
+        yt_b = (DV_prod * (ri_b - (recon_shape[0] - 1) / 2.0)).astype(np.float32)
+        xt_b = (DV_prod * (ci_b - (recon_shape[1] - 1) / 2.0)).astype(np.float32)
+        x_p_np  = ct * xt_b - st * yt_b
+        n_p_np  = ((x_p_np + OFF_prod) / DDC_prod + DCC_prod).astype(np.float32)
+        n_pc_np = np.round(n_p_np).astype(np.int32)
+
+        fr, fb = make_pair_npc_only(xt_b, yt_b)
+        a_v   = jnp.array(np.array([angle]))
+        npc_v = jnp.array(n_pc_np[None, :])
+        ref_v   = jax.jit(jax.vmap(fr))(a_v, npc_v)
+        buggy_v = jax.jit(jax.vmap(fb))(a_v, npc_v)
+        md = float(jnp.abs(ref_v - buggy_v).max())
+        worst = max(worst, md)
+        if md > 1e-3:
+            bad.append((B, md))
+    if not bad:
+        print(f"  {label:<55s}  ✓ all 24 batches clean (worst {worst:.2e})")
+    else:
+        details = ", ".join(f"BAD={B}({md:.3e})" for B, md in bad)
+        print(f"  {label:<55s}  ✗ {len(bad)} bad: {details}")
+
+bad_scan_npc_only("T15j precompute n_pc only (rest of geom in-jit)")
+
+
+print()
+print("=" * 70)
+print("Done.")
+print("=" * 70)

--- a/experiments/bugs_and_artifacts/jax rounding bug/lax_map_scatter_bug/vmap_lax_map_demo.py
+++ b/experiments/bugs_and_artifacts/jax rounding bug/lax_map_scatter_bug/vmap_lax_map_demo.py
@@ -1,0 +1,519 @@
+"""
+experiments/sharding/vmap_lax_map_demo.py
+──────────────────────────────────────────
+Annotated reproducer for a JAX/XLA bug:
+
+  jax.lax.scan (= jax.lax.map) + scatter-add produces incorrect results
+  for specific integer scatter-index patterns from the mbirjax pixel grid.
+
+CONTEXT
+───────
+mbirjax's parallel-beam CT forward projector uses jax.lax.map to iterate
+a scatter-add kernel over batches of reconstruction slices.  With the
+production geometry (integer pixel grid, N_ROWS=128, N_CHANNELS=256), two
+specific view angles (views 12 and 134 of 180) produce sinogram values
+that differ from the correct answer by ≈1.7 intensity units.
+
+SYMPTOMS
+────────
+• Error ≈ 1.7 at views 12 and 134.
+• Antisymmetric: energy is swapped between the channel just below and
+  just above each pixel's nearest detector channel (n_pc-1 ↔ n_pc+1).
+• Only PSF offsets ±1 are affected; offset 0 is always correct.
+• The bug does NOT require jax.vmap: it appears even when lax.map is
+  called directly (one view at a time) with concrete numpy geometry.
+
+ROOT CAUSE
+──────────
+The bug lives strictly below JAX's JAXPR level.  Evidence:
+
+  1. The scan body JAxPRs for the "angle-derived geometry" and
+     "explicit geometry" variants are bitwise identical (115 lines each),
+     yet one variant is buggy.  → Bug is in XLA compilation, not JAXPR.
+
+  2. jax.vmap(psb)(db) [same semantics as lax.map] is correct.
+     → Bug is specific to lax.scan's lowering of scatter-add.
+
+  3. The XLA scatter-add kernel appears to mis-handle the case where
+     the integer scatter index (n_pc ± 1) hits specific channel values
+     that arise from the production integer pixel grid.
+
+FIX
+───
+Replace  jax.lax.map(project_slice_batch, voxel_batched)
+with     jax.vmap(project_slice_batch)(voxel_batched).
+
+Both map project_slice_batch over the leading axis of voxel_batched;
+jax.vmap uses a different XLA lowering path that produces correct results.
+
+DEPENDENCIES
+────────────
+  • mbirjax (for parallel-beam geometry parameters)
+  • experiments/sharding/sharding_baseline_ref.npz  (pixel batch data)
+
+Run:
+  conda run -n mbirjax python experiments/sharding/vmap_lax_map_demo.py
+"""
+
+import os, sys
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=1")
+_sd = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath(os.path.join(_sd, '../../..', '..')))
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+import mbirjax
+from collections import namedtuple
+
+def get_2d_ror_mask(recon_shape):
+    """
+    Get a binary mask for the region of reconstruction.  By default, the mask is the largest possible circle
+    inscribed on the longest edge of the 2D recon_shape[0:2].
+
+    Args:
+        recon_shape (tuple): Shape of recon in (rows, columns, slices)
+        crop_radius_pixels (int): Number of pixels to subtract from the radius before creating the mask.
+        crop_radius_fraction (float): Fraction to subtract from the radius before creating the mask.
+
+    Returns:
+        A binary mask for the region of reconstruction.
+    """
+    # Set up a mask to zero out points outside the ROR
+    num_recon_rows, num_recon_cols = recon_shape[:2]
+    row_center = (num_recon_rows - 1) / 2
+    col_center = (num_recon_cols - 1) / 2
+
+    radius = max(row_center, col_center)
+
+    col_coords = np.arange(num_recon_cols) - col_center
+    row_coords = np.arange(num_recon_rows) - row_center
+
+    coords = np.meshgrid(col_coords, row_coords)  # Note the interchange of rows and columns for meshgrid
+    mask = coords[0]**2 + coords[1]**2 <= radius**2
+    mask = mask[:, :]
+    return mask
+
+
+def gen_pixel_partition(recon_shape, use_ror_mask=True):
+    """
+    Generates a partition of pixel indices into specified number of subsets for use in tomographic reconstruction algorithms.
+    The function ensures that each subset contains an equal number of pixels, suitable for VCD reconstruction.
+
+    Args:
+        recon_shape (tuple): Shape of recon in (rows, columns, slices)
+        use_ror_mask (bool): Flag to indicate whether to mask out a circular RoR
+
+    Raises:
+        ValueError: If the number of subsets specified is greater than the total number of pixels in the grid.
+
+    Returns:
+        jnp.array: A JAX array where each row corresponds to a subset of pixel indices, sorted within each subset.
+    """
+    # Determine the 2D indices within the RoR
+    num_recon_rows, num_recon_cols = recon_shape[:2]
+    max_index_val = num_recon_rows * num_recon_cols
+    indices = np.arange(max_index_val, dtype=np.int32)
+
+    # Mask off indices that are outside the region of reconstruction
+    if use_ror_mask:
+        mask = get_2d_ror_mask(recon_shape)
+        mask = mask.flatten()
+        indices = indices[mask == 1]
+
+    indices = jnp.sort(indices)
+
+    return jnp.array(indices)
+
+print("=" * 70)
+print("  vmap_lax_map_demo.py — lax.scan + scatter-add bug reproducer")
+print("=" * 70)
+print(f"  JAX version : {jax.__version__}")
+print()
+
+# ── mbirjax model and geometry ────────────────────────────────────────────────
+N_VIEWS = 180;  N_ROWS = 128;  N_CHANNELS = 256
+angles_np  = np.linspace(0, np.pi, N_VIEWS, endpoint=False)
+angles_jax = jnp.array(angles_np.astype(np.float32))
+# angles_jax = np.array((angles_jax[12], angles_jax[134]))
+
+model = mbirjax.ParallelBeamModel((N_VIEWS, N_ROWS, N_CHANNELS), angles_np)
+model.set_params(no_compile=True, no_warning=True)
+PP = namedtuple('PP', ['sinogram_shape', 'recon_shape', 'geometry_params'])
+recon_shape = model.get_params('recon_shape')
+pp = PP(model.get_params('sinogram_shape'),
+        recon_shape,
+        model.get_geometry_parameters())
+gp    = pp.geometry_params
+PSFSZ = int(gp.psf_radius)           # PSF half-width (= 1 for production)
+DV    = float(gp.delta_voxel)
+DDC   = float(gp.delta_det_channel)
+OFF   = float(gp.det_channel_offset)
+ND    = N_CHANNELS
+_B    = 16                            # slice batch size (_B in parallel_beam.py)
+_NB   = N_ROWS // _B                  # number of lax.map steps
+
+PBSZ = 2048  # Pixel batch size for vmap
+all_indices_np = gen_pixel_partition(recon_shape, use_ror_mask=True)
+flat_recon_np = np.random.rand(len(all_indices_np), N_ROWS)
+
+print(f"  PSF radius : {PSFSZ}")
+print(f"  DV={DV}, DDC={DDC}, OFF={OFF}")
+print(f"  _B={_B}, _NB={_NB}, ND={ND}")
+print()
+
+phantom = np.zeros(recon_shape)
+phantom = phantom.reshape((-1, recon_shape[2]))
+phantom[all_indices_np, :] = flat_recon_np
+phantom = phantom.reshape(recon_shape)
+phantom, sinogram, params = mbirjax.generate_demo_data(object_type='shepp-logan', model_type='parallel',
+                                                  num_views=N_VIEWS, num_det_rows=N_ROWS,
+                                                  num_det_channels=N_CHANNELS)
+flat_recon_np = phantom.reshape((-1, N_ROWS))
+
+# ── Select pixel batch 8 (contains views 12/134 with the bug) ─────────────────
+BAD = 8
+pb     = jnp.array(all_indices_np[BAD*PBSZ:(BAD+1)*PBSZ])   # (NP,)        pixel indices
+vb_all = flat_recon_np[pb]  # jnp.array(flat_recon_np [BAD*PBSZ:(BAD+1)*PBSZ])   # (NP, N_ROWS) voxel values
+NP     = vb_all.shape[0]
+
+
+
+# Convert flat pixel indices to (y, x) physical coordinates
+_rs = pp.recon_shape
+ri_np, ci_np = np.unravel_index(np.asarray(pb), _rs[:2])
+yt_arr = jnp.array((DV * (ri_np - (_rs[0]-1)/2.0)).astype(np.float32))  # (NP,)
+xt_arr = jnp.array((DV * (ci_np - (_rs[1]-1)/2.0)).astype(np.float32))  # (NP,)
+DCC = (ND - 1) / 2.0
+
+# Reshape voxels for lax.map: lax.map steps over the NB leading axis,
+# delivering one (_B, NP) slice batch per step.
+# vb_all.T has shape (N_ROWS, NP); reshape gives (NB, _B, NP).
+vb_batched = vb_all.T.reshape(_NB, _B, NP)   # (_NB, _B, NP)
+
+print(f"  Pixel batch: NP={NP}, voxel range=[{float(vb_all.min()):.3f}, {float(vb_all.max()):.3f}]")
+print()
+
+# ── Geometry helper ───────────────────────────────────────────────────────────
+def _geom(angle):
+    """
+    Compute per-pixel projection geometry for one view angle.
+    All returned values are derived from the vmapped `angle`; they carry
+    the vmap batch dimension and become scan-body constants under lax.map.
+    """
+    ct = jnp.cos(angle);  st = jnp.sin(angle)
+    x_p  = ct * xt_arr - st * yt_arr           # projected pixel position (NP,)
+    n_p  = (x_p + OFF) / DDC + DCC           # fractional channel index (NP,)
+    n_pc = jnp.round(n_p).astype(jnp.int32)    # nearest channel          (NP,)
+    cos_a = jnp.maximum(jnp.abs(ct), jnp.abs(st))
+    W_pc  = (DV / DDC) * cos_a                 # PSF full-width (scalar)
+    L_mx  = jnp.minimum(1.0, W_pc)             # PSF amplitude clamp
+    return n_p, n_pc, W_pc, cos_a, L_mx
+
+# ══════════════════════════════════════════════════════════════════════════════
+# Three implementations
+# ══════════════════════════════════════════════════════════════════════════════
+
+def forward_buggy(angle):
+    """
+    BUGGY: lax.map over slice batches.
+
+    project_slice_batch closes over n_p, n_pc, W_pc, cos_a, L_mx.
+    Under jax.lax.map (= lax.scan with empty carry), XLA compiles the
+    scatter-add incorrectly for the specific n_pc integer patterns that
+    arise from the mbirjax production pixel grid.  The bug appears for
+    PSF offsets ±1 (the adjacent-channel scatter), not for offset 0.
+    """
+    n_p, n_pc, W_pc, cos_a, L_mx = _geom(angle)
+
+    def project_slice_batch(vb_batch):   # vb_batch: (_B, NP)
+        sb = jnp.zeros((_B, ND))
+        for no in range(-PSFSZ, PSFSZ+1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc + 1.0)/2.0 - abs_d, 0.0, L_mx)
+            A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+            # Scatter: for each pixel p, add A[p]*vb_batch[:,p] into column n[p].
+            # This scatter-add is mis-compiled by XLA for specific n_pc patterns.
+            sb = sb.at[:, n].add(A * vb_batch)
+        return sb
+
+    return jax.lax.map(project_slice_batch, vb_batched).reshape(N_ROWS, ND)
+
+
+def forward_ref(angle):
+    """
+    REFERENCE: no inner batching — all slices projected in one scatter call.
+    Always correct.  Equivalent to the prerelease code path (Option A fix).
+    """
+    n_p, n_pc, W_pc, cos_a, L_mx = _geom(angle)
+    sino = jnp.zeros((N_ROWS, ND))
+    for no in range(-PSFSZ, PSFSZ+1):
+        n     = n_pc + no
+        abs_d = jnp.abs(n_p - n)
+        L     = jnp.clip((W_pc + 1.0)/2.0 - abs_d, 0.0, L_mx)
+        A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+        sino  = sino.at[:, n].add(A * vb_all.T)
+    return sino
+
+
+def forward_fixed(angle):
+    """
+    FIX: replace jax.lax.map with jax.vmap.
+
+    Semantically identical to forward_buggy — both iterate project_slice_batch
+    over the NB leading axis of vb_batched — but jax.vmap uses a different XLA
+    lowering path for the scatter-add that produces correct results.
+    """
+    n_p, n_pc, W_pc, cos_a, L_mx = _geom(angle)
+
+    def project_slice_batch(vb_batch):   # identical body to forward_buggy
+        sb = jnp.zeros((_B, ND))
+        for no in range(-PSFSZ, PSFSZ+1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc + 1.0)/2.0 - abs_d, 0.0, L_mx)
+            A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+            sb    = sb.at[:, n].add(A * vb_batch)
+        return sb
+
+    return jax.vmap(project_slice_batch)(vb_batched).reshape(N_ROWS, ND)  # ← key change
+
+
+# ── Run all three over all views ──────────────────────────────────────────────
+ref_orig = model.sparse_forward_project(vb_all, pb)
+
+ref_out   = jax.jit(jax.vmap(forward_ref)  )(angles_jax)
+buggy_out = jax.jit(jax.vmap(forward_buggy))(angles_jax)
+fixed_out = jax.jit(jax.vmap(forward_fixed))(angles_jax)
+
+# ══════════════════════════════════════════════════════════════════════════════
+# EVIDENCE 1 & 2: correctness
+# ══════════════════════════════════════════════════════════════════════════════
+print("─" * 70)
+print("EVIDENCE 1 & 2 — correctness check")
+print("─" * 70)
+
+diff_br = jnp.abs(buggy_out - ref_out)
+diff_fr = jnp.abs(fixed_out - ref_out)
+bug_max = float(diff_br.max())
+fix_max = float(diff_fr.max())
+bad_views = np.where(np.asarray(diff_br).max(axis=(1, 2)) > 0.01)[0].tolist()
+
+print(f"  buggy vs reference : max|diff| = {bug_max:.4e}  bad_views={bad_views}  "
+      f"{'✗ BUG' if bug_max > 0.01 else '?'}")
+print(f"  fixed vs reference : max|diff| = {fix_max:.4e}  "
+      f"{'✓ FIX CONFIRMED' if fix_max < 1e-5 else '✗'}")
+
+# Show the antisymmetric error pattern at the worst view
+for worst_view in bad_views:
+    # worst_view = int(np.argmax(np.asarray(diff_br).max(axis=(1, 2))))
+    signed_err = (buggy_out[worst_view] - ref_out[worst_view]).sum(axis=0)   # sum over slices
+    err_ch     = int(jnp.argmax(jnp.abs(signed_err)))
+    lo, hi     = max(0, err_ch - 3), min(ND, err_ch + 4)
+    print(f"\n  Signed error (summed over slices) at view {worst_view}, "
+          f"channels {lo}–{hi-1}:")
+    start_channel = -1
+    for ch in range(lo, hi):
+        e   = float(signed_err[ch])
+        tag = "← missing" if e < -0.01 else ("→ excess" if e > 0.01 else "")
+        if np.abs(e) > 0.01 and start_channel < 0:
+            start_channel = ch
+        print(f"    ch {ch:3d}: {e:+.4f}  {tag}")
+    print()
+    print("  The error is antisymmetric: energy swapped between n_pc-1 and")
+    print("  n_pc+1 channels.  Both offsets +1 and -1 are independently buggy.")
+
+    a = forward_ref(angles_jax[worst_view])
+    n_p, n_pc, W_pc, cos_a, L_mx = _geom(angles_jax[worst_view])
+    print('Projections of centers of pixels')
+    for j in range(3):
+        a = np.where(n_pc == start_channel + j)[0]
+        print('Channel {}:'.format(start_channel + j))
+        with np.printoptions(precision=17, floatmode='unique'):
+            print(n_p[a])
+print()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# EVIDENCE 3: offset isolation
+# ══════════════════════════════════════════════════════════════════════════════
+print("─" * 70)
+print("EVIDENCE 3 — offset isolation (which PSF offsets trigger the bug?)")
+print("─" * 70)
+
+def _make_fwd_buggy(offsets):
+    def fwd(angle):
+        n_p, n_pc, W_pc, cos_a, L_mx = _geom(angle)
+        def psb(vb_batch):
+            sb = jnp.zeros((_B, ND))
+            for no in offsets:
+                n     = n_pc + no
+                abs_d = jnp.abs(n_p - n)
+                L     = jnp.clip((W_pc+1.0)/2.0 - abs_d, 0.0, L_mx)
+                A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+                sb    = sb.at[:, n].add(A * vb_batch)
+            return sb
+        return jax.lax.map(psb, vb_batched).reshape(N_ROWS, ND)
+    return fwd
+
+def _make_fwd_ref(offsets):
+    def fwd(angle):
+        n_p, n_pc, W_pc, cos_a, L_mx = _geom(angle)
+        sino = jnp.zeros((N_ROWS, ND))
+        for no in offsets:
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc+1.0)/2.0 - abs_d, 0.0, L_mx)
+            A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+            sino  = sino.at[:, n].add(A * vb_all.T)
+        return sino
+    return fwd
+
+for offsets in [[0], [-1], [1], [-1, 0, 1]]:
+    ob  = jax.jit(jax.vmap(_make_fwd_buggy(offsets)))(angles_jax)
+    ref = jax.jit(jax.vmap(_make_fwd_ref(offsets))  )(angles_jax)
+    md  = float(jnp.abs(ob - ref).max())
+    bv  = np.where(np.asarray(jnp.abs(ob-ref)).max(axis=(1,2)) > 0.01)[0].tolist()
+    status = '✗ BUG' if md > 0.01 else '✓ OK '
+    print(f"  offsets {str(offsets):<12}: max|diff|={md:.4e}  bad_views={bv}  {status}")
+
+print()
+print("  offset=0 is always correct.  offsets ±1 each independently trigger")
+print("  the bug, confirming the issue is in the adjacent-channel scatter.")
+print()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# EVIDENCE 4: JAXPR scan-body comparison
+#
+# We compare the scan body of:
+#   fn_1A — geometry passed as explicit vmap args (in_axes=0 for each array)
+#   fn_1B — geometry derived from vmapped angle  (= forward_buggy)
+#
+# If the bodies are bitwise identical, the bug cannot be in the JAXPR; it
+# must be in XLA's lowering of the batched lax.scan → scatter-add.
+# ══════════════════════════════════════════════════════════════════════════════
+print("─" * 70)
+print("EVIDENCE 4 — JAXPR scan-body comparison (confirms XLA-level bug)")
+print("─" * 70)
+
+# Pre-compute geometry arrays for all views (needed by fn_1A)
+def _geom_np(angle_f):
+    ct, st = np.cos(angle_f), np.sin(angle_f)
+    xp = ct*np.asarray(xt_arr) - st*np.asarray(yt_arr)
+    np_ = (xp + OFF)/DDC + DCC
+    npc = np.round(np_).astype(np.int32)
+    ca  = max(abs(ct), abs(st))
+    Wp  = np.float32((DV/DDC)*ca)
+    Lm  = np.float32(min(1.0, float(Wp)))
+    return np_.astype(np.float32), npc, Wp, np.float32(ca), Lm
+
+n_p_all  = jnp.array(np.stack([_geom_np(float(a))[0] for a in angles_np]))  # (NV,NP)
+n_pc_all = jnp.array(np.stack([_geom_np(float(a))[1] for a in angles_np]))  # (NV,NP)
+W_all    = jnp.array(np.array( [_geom_np(float(a))[2] for a in angles_np])) # (NV,)
+cos_all  = jnp.array(np.array( [_geom_np(float(a))[3] for a in angles_np])) # (NV,)
+Lmx_all  = jnp.array(np.array( [_geom_np(float(a))[4] for a in angles_np])) # (NV,)
+
+
+def fn_1A(n_p, n_pc, W_pc, cos_a, L_mx):
+    """Explicit geometry as vmap args — scan body identical to fn_1B."""
+    def psb(vb_batch):
+        sb = jnp.zeros((_B, ND))
+        for no in range(-PSFSZ, PSFSZ+1):
+            n     = n_pc + no
+            abs_d = jnp.abs(n_p - n)
+            L     = jnp.clip((W_pc+1.0)/2.0 - abs_d, 0.0, L_mx)
+            A     = DV * L / cos_a * ((n >= 0) & (n < ND))
+            sb    = sb.at[:, n].add(A * vb_batch)
+        return sb
+    return jax.lax.map(psb, vb_batched).reshape(N_ROWS, ND)
+
+
+# fn_1B is identical to forward_buggy — geometry derived from vmapped angle
+fn_1B = forward_buggy
+
+jpr_1A = jax.make_jaxpr(jax.vmap(fn_1A, in_axes=(0,0,0,0,0)))(
+    n_p_all, n_pc_all, W_all, cos_all, Lmx_all)
+jpr_1B = jax.make_jaxpr(jax.vmap(fn_1B))(angles_jax)
+
+
+def find_scan_eqn(jpr):
+    for eqn in jpr.jaxpr.eqns:
+        if str(eqn.primitive) == 'scan':
+            return eqn
+    return None
+
+
+scan_1A = find_scan_eqn(jpr_1A)
+scan_1B = find_scan_eqn(jpr_1B)
+
+if scan_1A and scan_1B:
+    body_str_1A = str(scan_1A.params['jaxpr'])
+    body_str_1B = str(scan_1B.params['jaxpr'])
+    identical   = (body_str_1A == body_str_1B)
+    n_lines     = len(body_str_1A.splitlines())
+
+    print(f"  fn_1A scan body: {n_lines} lines  "
+          f"(params: length={scan_1A.params.get('length')}, "
+          f"num_consts={scan_1A.params.get('num_consts')})")
+    print(f"  fn_1B scan body: {len(body_str_1B.splitlines())} lines  "
+          f"(params: length={scan_1B.params.get('length')}, "
+          f"num_consts={scan_1B.params.get('num_consts')})")
+    print(f"  Bodies identical: {identical}")
+    print()
+
+    if identical:
+        print("  ✓ CONCLUSION: scan bodies are bitwise identical.")
+        print("    fn_1A uses geometry arrays passed as vmapped args.")
+        print("    fn_1B derives geometry from the vmapped angle.")
+        print("    Both trace to the exact same 115-line scan body JAXPR.")
+        print("    The bug is therefore in XLA's lowering of the batched")
+        print("    lax.scan, NOT in JAX's JAXPR generation.")
+
+    # Print the scan invars so the reader can see the batched shapes
+    print()
+    print("  fn_1B scan invars (closed-over constants, batched over NV views):")
+    for v in scan_1B.invars:
+        print(f"    {v.aval}")
+    print()
+    print("  int32[NV,NP] is n_pc (scatter index), batched over all views.")
+    print("  XLA receives a 2-D scatter index inside the scan and compiles")
+    print("  the scatter-add incorrectly for certain integer index patterns.")
+else:
+    print("  ERROR: could not find scan equation in JAXPR (unexpected)")
+
+print()
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SUMMARY
+# ══════════════════════════════════════════════════════════════════════════════
+print("=" * 70)
+print("SUMMARY")
+print("=" * 70)
+print()
+print("  Bug  :  jax.lax.scan scatter-add produces wrong results for the")
+print("          specific integer scatter-index patterns arising from the")
+print("          mbirjax production pixel grid.  Visible as ≈1.7-unit errors")
+print("          at views 12 and 134 with antisymmetric channel swaps.")
+print()
+print("  Cause:  XLA mis-compiles the scatter-add for specific n_pc patterns.")
+print("          The JAXPR is correct (scan bodies bitwise identical for")
+print("          derived-geometry and explicit-geometry variants).")
+print("          Note: the bug also appears WITHOUT jax.vmap — running one")
+print("          view at a time with numpy-materialized geometry still hits it.")
+print()
+print("  Fix  :  Replace  jax.lax.map(f, xs)  with  jax.vmap(f)(xs).")
+print("          Both iterate f over the leading axis of xs; vmap uses a")
+print("          different XLA lowering path that produces correct results.")
+print()
+print("  Alt  :  Remove inner slice batching entirely (prerelease / Option A):")
+print("          scatter all slices in one call per view.")
+print()
+print(f"  JAX  :  {jax.__version__}")
+print()
+
+mbirjax.slice_viewer(ref_orig, ref_out, 10 * (buggy_out-ref_out), slice_axis=0,
+                     title='Forward projection. Left: current implementation, Mid: ref, Right: 10*(ref - buggy) (right)\nLook at views 12 and 134',
+                     vmin=-5, vmax=10)


### PR DESCRIPTION
These files describe a subtle bug deep in the innards of jax compilation.  Under some circumstances, jnp.round() inside some nested vmap and lax.map calls can give results that are different in the producing function than in the function that called it.  It's very difficult to get rid of this bug, but it also doesn't appear all that often.  

jax_rounding_bug.md describes the problem, the investigation, and the proposed solution, which is to precompute the rounded values outside the jitted function.  