### PR TITLE
Fix bug in Zeiss cone beam preprocessing

### DIFF
--- a/mbirjax/denoising.py
+++ b/mbirjax/denoising.py
@@ -160,13 +160,10 @@ class QGGMRFDenoiser(TomographyModel):
         Args:
             image (numpy or jax array):  The 3D volume to be denoised.
             sigma_noise (float, optional):  The estimated noise variance in the noisy image.  If None, then the noise level is estimated from the image.
-            use_ror_mask: Option to restrict denoising to a masked region in the image. Defaults to False.
-                False:
-                    No mask.
-                True:
-                    The mask is an ellipse inscribed in the reconstruction volume.
-                2D array:
-                    Use a custom binary mask. Must have shape recon_shape[:2].
+            use_ror_mask: Option to restrict denoising to a masked region in the image.
+                Defaults to False. Use False for no mask, True for an ellipse inscribed in
+                the reconstruction volume, or a custom binary 2D array with shape
+                ``recon_shape[:2]``.
             init_image (numpy or jax array, optional):  An initial image for the minimization.  Defaults to image.
             max_iterations (int, optional): maximum number of iterations of the VCD algorithm to perform.
             stop_threshold_change_pct (float, optional): Stop reconstruction when 100 * ||delta_recon||_1 / ||recon||_1 change from one iteration to the next is below stop_threshold_change_pct.  Defaults to 0.2.  Set this to 0 to guarantee exactly max_iterations.

--- a/mbirjax/preprocess/zeiss_cb.py
+++ b/mbirjax/preprocess/zeiss_cb.py
@@ -341,6 +341,10 @@ def convert_zeiss_to_mbirjax_params(zeiss_params, downsample_factor=(1, 1), crop
     delta_det_channel = magnification * iso_pixel_pitch
     delta_det_row = magnification * iso_pixel_pitch
 
+    # Convert to ALU: This assumes that the det_channel_offset and det_row_offset have units of pixels.
+    det_channel_offset *= delta_det_channel
+    det_row_offset *= delta_det_row
+
     # Adjust detector size params w.r.t. cropping arguments
     num_det_rows = num_det_rows - (crop_pixels_top + crop_pixels_bottom)
     num_det_channels = num_det_channels - 2 * crop_pixels_sides
@@ -353,10 +357,6 @@ def convert_zeiss_to_mbirjax_params(zeiss_params, downsample_factor=(1, 1), crop
     delta_det_channel *= downsample_factor[1]
 
     iso_pixel_pitch *= downsample_factor[0]
-
-    # Convert to ALU: This assumes that the det_channel_offset and det_row_offset have units of pixels.
-    det_channel_offset *= delta_det_channel
-    det_row_offset *= delta_det_row
 
     # Create a dictionary to store MBIR parameters
     num_views = len(angles)
@@ -564,7 +564,7 @@ def read_metadata(ole):
         'num_reference': number_of_reference,
         'iso_pixel_pitch': _read_ole_value(ole, 'ImageInfo/PixelSize', '<f'),
         'det_pixel_pitch': _read_ole_value(ole, 'ImageInfo/CamPixelSize', '<f'),
-        'iso_det_dist': _read_ole_value(ole, 'ImageInfo/D2RADistance', '<f'),
+        'iso_det_dist': _read_ole_value(ole, 'ImageInfo/DtoRADistance', "<{0}f".format(number_of_images)),
         'source_iso_dist': _read_ole_value(ole,'ImageInfo/StoRADistance', "<{0}f".format(number_of_images)),
         'thetas': _read_ole_arr(
             ole, 'ImageInfo/Angles', "<{0}f".format(number_of_images)),


### PR DESCRIPTION
This PR fix the two bugs in Zeiss cone beam preprocessing code

1. Fixed incorrect detector channel offset scaling when downsampling factor is greater than 1

2. Fixed incorrect metadata path for reading the iso-to-detector distance from Zeiss .txrm files

To test this PR, please run Cone_beam_exp_Zeiss.py in exeperiments/zeiss folder and set dataser_index = 1

All pytests passed on my end