### PR TITLE
Greg/shard profiling

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -542,6 +542,34 @@ contaminates, or NaNs.**
   the SAME model under test (`self._make_model()`, `model.get_params('recon_shape')`), and don't
   hardcode a real slice count (helical ≠ num_det_rows) — read it from params.
 
+## Out-of-pool GPU allocations vs a near-total BFC reservation (2026-07-02)
+
+With `XLA_PYTHON_CLIENT_MEM_FRACTION=0.98`, everything that allocates OUTSIDE XLA's BFC pool has
+~1.5 GB to live in — and the pool RETAINS its high-water mark (`pool_bytes` stays at the process peak
+even when `bytes_in_use` returns to ~0), so late-in-the-run out-of-pool allocations starve even on an
+"idle" GPU.  Two distinct sub-classes, one diagnostic, one policy:
+
+1. **cuSolver-family** (`jnp.linalg.solve/svd/eig/cholesky/inv`): the library's handle/workspace is
+   allocated outside the pool and fails (`gpusolverDnCreate ... cuSolver internal error`) even with the
+   pool mostly free — and the dispatch is ASYNC, so the error surfaces only when the result is first
+   read, far from the call.  Policy: for small systems (e.g. the MAR 15×15 QP), gather to host and use
+   `np.linalg` (done in `_estimate_BH_model_params_using_OSQP`); for large ones, budget pool headroom.
+2. **NCCL/collective buffers** (`cuda_vmm allocator ... RESOURCE_EXHAUSTED`): any eager op on a SHARDED
+   array that reduces cross-device (even `jnp.linalg.norm`, which is pure XLA — no cuSolver) allocates
+   collective buffers via the vmm allocator, outside the pool.  Each SEPARATE eager op/executable can
+   carry its own collective allocation, so per-iteration eager stats (loss, norm, L1) multiply the
+   exposure.  Policy: jit the recon-loop statistics into ONE function (one executable, one set of
+   collective buffers, and the fusion also removes the full-size eager temps) — see
+   `_vcd_iteration_stats` / the jitted `get_forward_model_loss` / `_gen_huber_weights_kernel`.
+
+Diagnostics: `bytes_in_use` is the WRONG ruler for this class — check `pool_bytes`/`peak_pool_bytes`
+(the retained reservation) at the failure point; the confirming ablation is lowering the mem fraction.
+CONFIRMED on the cluster 2026-07-02: at the norm-OOM point `bytes_in_use` = 0.64 GB while `pool_bytes`
+= 83.3 GB (the full reservation), and fraction 0.94 eliminated the OOM.  FIXED: `tomography_model.py`
+now uses `os.environ.setdefault('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.94')` — a conservative default
+with out-of-pool headroom, overridable per-run via the environment (it was a hard-set '0.98' that the
+env var could not override).
+
 ## Tooling / harness
 
 - **A modern `pip install -e` overrides `PYTHONPATH` — prepending a checkout to `PYTHONPATH` does NOT

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -1,677 +1,242 @@
 # Engineering lessons (mbirjax sharding)
 
-Hard-won lessons from the sharding effort — the F1 sharded FBP filter, the Phase D
-back-projection reduce-scatter, the placement architecture, sharded-VCD memory + buffer
-donation, and the platform-divergent back kernel — kept as a reference playbook.  The short
-jax/perf tips live in `claude_prompt.md` and the general measurement principles in global
-memory; this is the detailed version, with the worked examples.
+Operative rules from the sharding effort, organized by development question.  Each entry: the rule,
+the mechanism, the tell, and a code pointer as the worked example.  Full discovery narratives (the F1
+and Phase D case studies, per-entry history) live in this file's git history (pre-2026-07-03
+consolidation).  The general measurement principles also live in global `~/.claude/CLAUDE.md`; the
+short jax/perf tips in `claude_prompt.md`.
 
-## General principles (apply anywhere)
+## Contents
 
-- **Separate the ruler from the measured.**  When a number looks wrong, suspect
-  the harness/measurement before the code.  In F1, most "memory problems" were
-  measurement artifacts, not the kernel.
-- **Trust authoritative introspection over end-to-end numbers.**  XLA's
-  `compiled.memory_analysis()` (temp = 94 MB) and the compiled HLO proved the
-  kernel was already at the 2× floor — one number redirected the whole hunt from
-  the kernel to the harness.
-- **Decide with cheap, single-variable ablations.**  Vary one thing, hold the
-  rest fixed.  Examples here: a jit-on/off microbench isolated the scaling cause;
-  preallocate true-vs-false on one config verified memory honesty; the
-  divisibility "smoking gun" (1624² ÷ 64 but not ÷ 256) attributed a memory step
-  to padding.
-- **Name the assumption a fix rests on, then verify it.**  "The scan updates its
-  carry in place — confirm on GPU" held; "the body/tail output concat might not
-  fuse" came true.  Stating the risk caught the dead end fast.
-- **Sweep parameters; don't guess defaults.**  B=1024 and the c-dependence came
-  from the B-sweep, not intuition.
+1. [General principles](#1-general-principles)
+2. [Float correctness gates](#2-float-correctness-gates)
+3. [Writing sharded / jitted code](#3-writing-sharded--jitted-code)
+4. [The 2^31 / dtype boundary](#4-the-231--dtype-boundary)
+5. [Measuring honestly (the ruler)](#5-measuring-honestly-the-ruler)
+6. [Performance expectations](#6-performance-expectations)
+7. [Out-of-pool GPU allocations](#7-out-of-pool-gpu-allocations)
+8. [Known-benign warnings](#8-known-benign-warnings)
+9. [Tooling / harness](#9-tooling--harness)
 
-## jax / GPU specifics
+## 1. General principles
 
-- **Jit per-worker compute.**  The per-device kernel had lost `@jax.jit` → eager,
-  op-by-op dispatch → ~2× instead of ~6.5× scaling.  Every threaded worker's
-  compute must compile.
-- **Bound work-area memory by a fixed batch, not geometry.**  per_view's FFT
-  batch = `view_batch_size × n_rows` grew with the detector and OOM'd at 1624³;
-  the row-batched kernel made memory depend on `B` alone (ROW_FILTER_BATCH),
-  independent of geometry and device count.
-- **`peak_bytes_in_use` is a process-cumulative high-water mark.**  It never
-  resets within a process, so honest per-config memory needs a fresh subprocess
-  per config — and the orchestrator must touch no JAX (or it holds device memory
-  while a worker measures).  `preallocate=true` reports the *same* peak (it tracks
-  in-use tensors, not the pool) and avoids the per-call `cudaMalloc` growth that
-  inflates timing.
-- **Free the previous result in a timing loop.**  Holding the prior output while
-  the next allocates over-reports memory by a full shard and causes allocation
-  thrash (which also inflated timing).
-- **Watch for hidden memory use.**  `np.pi` is float64;
-  `f32_array * f64_scalar` (out of place) promotes the whole array to f64 →
-  doubles memory (the f64 OOM).  Fold the scalar into a small operand (the f32
-  filter); convolution's linearity makes it free.
-- **Avoid hidden full-shard copies in batched kernels.**  Both an input zero-pad
-  `concatenate` and a body/tail output `concatenate` each silently re-add a full
-  shard.  A `lax.scan` over overlapping windows that writes in place via
-  `dynamic_update_slice` (clamp the last window in-bounds; the overlap is
-  idempotent for a per-row op) avoids both — hitting the input+output floor.
-- **`lax.map(batch_size=…)` is unsafe for large batches (jax#27591).**  Supply the
-  parallelism with `vmap` and scan with no `batch_size` to stay immune.
-- **CPU sharding is a REAL speedup — take it seriously (users run on CPU).**
-  Measured ~5.4–6.5× at 8 virtual CPU devices (device sweep).  The filter is
-  embarrassingly parallel across views, and `run_per_device` runs one thread per
-  virtual CPU device with the GIL released during XLA execution, so N independent
-  shard-streams genuinely spread across cores — extracting parallelism a single
-  CPU device's intra-op threading does not fully get for this scan/FFT workload.
-  (Don't assert "CPU sharding won't help" from a model — the data says it does;
-  this is the ruler-vs-measured lesson, self-inflicted.)  Caveats: on CPU the
-  memory metric is whole-process RSS, not the per-device 2× floor, and RSS grows
-  with device count — CPU sharding trades some memory for speed.  This is all
-  SINGLE-PROCESS (the cores of one machine); spanning multiple nodes still needs
-  multi-host JAX (`jax.distributed`).
+- **Separate the ruler from the measured.**  When a number looks wrong, suspect the
+  harness/measurement before the code — a large fraction of "bugs" live in how something is measured.
+- **Trust authoritative introspection over end-to-end numbers.**  `compiled.memory_analysis()`,
+  compiled HLO, `memory_stats()`, `nvidia-smi dmon` attribute a problem before you optimize it.
+- **Decide with cheap, single-variable ablations.**  Vary exactly one thing; design the smallest
+  experiment that discriminates between competing hypotheses.
+- **Name the assumption a fix rests on, then verify it** — rather than assuming.
+- **Sweep parameters; don't guess defaults.**  Let data pick the knee/threshold.
 
-- **Per-subset sharding has a problem-SIZE floor — measure VCD at realistic sizes,
-  not toy ones (ruler lesson, self-inflicted).**  VCD reuses the same sharded
-  projectors but calls them over a *subset* of pixels each update
-  (`recon_pixels / num_subsets`), so the effective work per sharded op is far
-  smaller than a full projection — VCD needs a *bigger* recon than the bare
-  projectors to amortize the per-device + per-subset overhead.  A first
-  shard-vs-noshard demo at 64³ showed VCD ~0.35× at 4 CPU devices and I wrongly
-  called it "expected sharding overhead."  It was a too-small ruler: the bare back
-  projector is itself only 0.44× at 4 dev at 64³ (it doesn't beat 1× on CPU until
-  ~256³).  Measured VCD CPU scaling (4 virtual devices): 64³ ≈ 0.35×, 128³ ≈ 0.86×,
-  **256³ ≈ 1.70×** — right in line with the projectors' CPU ceiling (back ~1.9×,
-  forward ~1.6× at 256³).  So sub-256³ "slowdowns" are the size, not a defect; never
-  conclude "sharding doesn't help here" from a toy size.  Full CPU device curve at
-  256³: 2d 1.63×, **4d 1.86×**, 8d 1.73× — 2-dev already wins, **4 dev is the peak,
-  8 dev regresses** (bandwidth-bound on the shared CPU memory bus, like back-proj);
-  384³ is slightly worse (4d 1.75×, 8d 1.41×) as larger working sets saturate the bus
-  sooner.  ~4 devices is the CPU sweet spot.
-- **VCD's sharded qGGMRF prior is the one per-subset component that goes BACKWARDS
-  at fine granularity** (attribution at 256³/4-dev: prior 0.47× on 1024-pixel
-  subsets vs 1.45× on 16384-pixel subsets; back/forward stay ≥1.3×).  Cause: its
-  host-halo extraction (`_extract_halos` ≈ 1.35 ms/call) + the per-shard Python
-  dispatch + `assemble_sharded` don't amortize when the actual prior compute is ~2
-  ms.  It's only ~8% of per-subset cost (the projections dominate), so it drags
-  overall VCD scaling only slightly — but it's the obvious optimization if the prior
-  ever dominates: avoid the per-subset host round-trip (on-device `move_shard` halo
-  exchange where d2d is safe, or fuse the halo read across subsets).
-- **GPU watch for VCD:** the line-search `alpha` is reduced to a host float each
-  subset (5 `float()` device→host syncs/subset) to dodge the cross-mesh scalar
-  problem (forward scalars on the sino mesh, prior scalars on the recon mesh).
-  Cheap on CPU; potentially serializing on GPU.  If it bites, replicate `alpha`
-  onto both meshes with `device_put` (a couple of scalar broadcasts) instead of
-  bouncing through the host.  **Confirmed on GPU (2026-06-05) via a full op sweep — and it is VCD-SPECIFIC, not a
-  size floor.**  On the SAME H100×4 allocation, at 4 dev every bare op scales (256³:
-  back 2.51×, direct 2.78×, forward 4.00×; 512³: fbp 3.10×, back 3.33×, direct 3.65×,
-  forward 4.75×) while vcd_recon alone is 0.28× (256³) / 1.62× (512³).  So "256³ is too
-  small for GPU" is FALSE — the projectors scale there; VCD doesn't because it calls
-  them per subset (`recon_pixels/num_subsets` pixels), so each op does num_subsets× less
-  work against a fixed per-subset host overhead.  CPU clinches that the overhead is host
-  round-trips: at 256³/4d VCD scales like the others on CPU (2.10×) but collapses on GPU
-  (0.28×).  Fix = A/B/alpha (cut the per-subset host round-trips); target = move GPU
-  512³/4d from 1.62× toward the projectors' ~3.3×.
-- **`CUDA_ERROR_NOT_PERMITTED` from `cuda_vmm_allocator.cc` ("VMM cuMemCreate with
-  FABRIC+POSIX_FD handle types failed … will retry with simpler handle types") is a
-  BENIGN warning, not a failure — don't chase it.**  XLA's VMM allocator probes
-  advanced memory-handle types (multi-node NVLink fabric / fd-based IPC) on the first
-  multi-GPU allocation; when the job's environment forbids them it falls back to
-  simpler handles and the allocation + any collective succeed (verified: a standalone
-  multi-GPU `jnp.sum` emits the warnings AND returns the right value; the full run
-  exits 0 with correct output).  It's a `W` line; real errors are `E`/`F` or a Python
-  traceback.  Silence with `TF_CPP_MIN_LOG_LEVEL=2`.  (I twice mis-attributed it — to
-  an orchestrator JAX-import and then to a blocked P2P collective — before the
-  standalone ablation showed it's noise.  Distinguish warning-vs-fatal FIRST.)
-- **On GPU, sharding is primarily a CAPACITY tool, not a speed tool.**  Per-device
-  memory drops a lot with more devices (1 device holds full transients; multi-device
-  streams in bands), so you shard to fit a bigger recon, and any speedup past the
-  crossover is a bonus.  Don't read inverted *time* at a fits-on-one-GPU size as a
-  defect — read whether *memory* shards (it does) and whether time scales *above* the
-  crossover (it does: 512³ 1.65×@2d).
-- **`peak_bytes_in_use` is the REAL live working set and is preallocation-INVARIANT;
-  `PREALLOCATE=false` does NOT reveal the capacity floor — restrict the budget instead
-  (ruler caution, Greg; I initially got this backwards).**  Verified: rerunning with
-  preallocation off gave the SAME peak (1d 512³ ≈ 41.6 GB either way).  `peak_bytes_in_use`
-  is the peak of *live* (in-use) bytes, not the reserved pool, so preallocation doesn't
-  change it.  Under a *generous* budget XLA does no rematerialization, so this peak is the
-  natural full-speed working set — a real number (so the ~10× 1d→Nd drop from band-streaming +
-  sharding is genuine, NOT a preallocation artifact; my earlier "preallocation over-reports
-  the 1d number" was wrong).  Caveats that DO hold: don't extrapolate absolute MB across sizes
-  (the natural working set isn't a clean ×k in size), and to find the true **capacity floor /
-  OOM threshold** you must ARTIFICIALLY RESTRICT the budget — keep `PREALLOCATE=true` and LOWER
-  `XLA_PYTHON_CLIENT_MEM_FRACTION` (a hard pool cap, e.g. 0.25) so XLA rematerializes to fit;
-  a size that then OOMs is the honest max-recon-per-GPU.  (`MEM_FRACTION` is ignored when
-  `PREALLOCATE=false`, the other reason False is useless for this.)  See the continue-past-OOM
-  sweep (`sparse_back_project_single_device_sweep.py`) and per-buffer attribution
-  (`sparse_back_project_memory_attribution.py`); `vcd_recon_scaling.py` exposes `MEM_FRACTION`.
-- **An OOM can surface as an unrelated-looking error — classify it from the FULL traceback,
-  and don't let a harness swallow the stack.**  A 1008³/1d VCD run failed with numpy's
-  "setting an array element with a sequence" and `oom=False`, because the real
-  RESOURCE_EXHAUSTED was deeper in the stack and the harness only stored `str(e)[:300]`.  Fix:
-  record `traceback.format_exc()` and match OOM markers against the whole traceback, not just
-  the top-level message.
+## 2. Float correctness gates
 
-## Phase F1 case study (the arc)
+- **Exact equality is NEVER the right gate for COMPUTED floats** (project rule, Greg).  Two separate
+  executables differ ~1 ULP even for identical programs (GPU autotuning); one executable run twice
+  differs on GPU (scatter-add atomics reorder sums); and CPU is deterministic only WITHIN a process —
+  the reduce-scatter summation order varies process-to-process, so "bit-exact on CPU" tests flake.
+- **Gate sharded-vs-single comparisons on a scale-invariant relative max:**
+  `max|out − ref| / max|ref| ≤ tol` (`tests/sharding/conftest.rel_max_err` /
+  `assert_sharded_allclose`).  NOT a fixed `atol` (scale-dependent: passes small-magnitude operators,
+  false-fails large ones for the same relative noise) and NOT per-element `rtol` (near-zero entries,
+  whose noise comes from large cancelling terms, get near-zero thresholds).
+- **Calibration:** same-executable GPU run-to-run noise on the projectors reaches ~8e-6 RELATIVE
+  (~70 ULP, atomics), so anything touching the projectors gates at 1e-5 single-shot / 1e-4 iterated;
+  pure elementwise kernels (qGGMRF cylinder) are safe at 1e-6.
+- **Exact equality remains correct for exactly two things:** (1) DATA-MOVEMENT identities
+  (shard/gather/assemble round trips, halo extraction, stored-parameter echo — bytes in = bytes out;
+  a tolerance would mask corruption); (2) CONSTRUCTED-ZERO invariants (padded entries == 0.0 — an
+  allclose would hide a leak into the padding).
+- **Seed any global-RNG dependence before a cross-config comparison.**  VCD pixel partitions draw
+  from global `np.random`; unseeded, a sharded-vs-n=1 fingerprint showed ~1e-4 reldiff (100× the
+  float floor) purely from different partitions.  `np.random.seed(k)` before each call isolates the
+  dimension under test; otherwise you are comparing noise.
 
-The sharded FBP filter, start to finish — a template for "make it correct, then
-fast, then honest":
+## 3. Writing sharded / jitted code
 
-1. **Scaling gap → jit.**  Beta scaled ~2× vs research's ~6.5× on CPU.  A
-   jit-toggle microbench (eager vs jitted, view vs row axis) isolated the cause:
-   the kernels had lost `@jax.jit`.  Restoring it closed the gap and ruled out
-   the shard-axis and kernel-structure theories.
-2. **Memory blowup → work area.**  On the H100, 1624³ OOM'd at 1 device.  Root
-   cause: per_view's FFT work area = `view_batch_size × n_rows`, geometry-bound.
-   Fix: the row-batched kernel — bound the FFT batch by `B` alone.
-3. **The reshape, done right.**  First a whole-array zero-pad (a full-shard
-   transient), then body/tail + concat (traded the input copy for an output
-   copy — net zero, caught by the data), finally an overlapping-window scan
-   writing in place (the floor).  Each step verified on the H100.
-4. **f64 OOM.**  The `* (np.pi/num_views)` post-multiply promoted f32→f64 (the
-   `jit_multiply` OOMs).  Folded both scalars into the f32 filter.
-5. **The ruler was lying.**  The remaining "3.5× memory" and "row_batch slower
-   than per_view" were harness artifacts: the timing loop held the previous
-   result (over-reporting by a shard + allocation thrash).  `memory_analysis()`
-   proved the kernel was at 2× — the fix was in `time_op`, not the kernel.
-6. **Pick B by sweeping.**  The B-sweep gave the knee (1024): ~10× faster than a
-   small batch, with the benefit past 1024 shrinking as channels grow while the
-   work area grows — pointing at a future c-aware `B ≈ budget/fft_len(c)`.
-7. **Consolidate.**  One kernel (`tomography_utils.apply_row_filter`); the switch
-   and losing kernels removed; `view_batch_size` deprecated on user-facing
-   methods.
+- **Jit per-worker compute.**  Eager op-by-op dispatch silently kills multi-device scaling (a lost
+  `@jax.jit` turned ~6.5× into ~2×) and materializes every intermediate at peak memory.
+- **Fuse recon-loop statistics into ONE jitted function.**  Each separate eager op on a sharded array
+  carries its own full-size temps AND its own collective-buffer allocation; one jitted stats function
+  = one executable, one collective set, no temps (`TomographyModel._vcd_iteration_stats`).
+- **Bound working memory by a fixed batch/slab, not by geometry.**  A work area proportional to
+  detector size OOMs at large geometry; a `B`-bounded batch is geometry- and device-count-independent
+  (`apply_row_filter`'s B; the histogram's `_HISTOGRAM_SLAB_ELEMENTS`).
+- **Close over HOST (NumPy) constants for device-agnostic kernels** — they auto-promote to each
+  batch's device.  But **`@jax.jit` defeats the host-preserving `xp = jnp if isinstance(x, jax.Array)
+  else np` pattern**: jit traces the input and always returns a device array, so the branch is inert
+  and the volume ships to one device.  Host-preserving functions must run eagerly (de-jit non-hot
+  ops) or branch BEFORE the jit boundary.
+- **Avoid hidden full-shard copies in batched kernels.**  An input zero-pad `concatenate` and a
+  body/tail output `concatenate` each silently re-add a full shard.  Two valid fixes, chosen by cost
+  structure: for a cheap idempotent per-row op, an overlapping-window `lax.scan` writing in place via
+  `dynamic_update_slice`; for an expensive band (a projector call), balanced equal bands with zero
+  recompute — an overlapping tail there nearly doubles a band's work.
+- **Never slice or stride a SHARDED axis.**  A non-shard-aligned slice comes back `P()` — fully
+  REPLICATED, a complete copy on every device (bit `split_sino_recon`'s `init_recon` half-slice; a
+  strided subsample would do the same).  Gather to host at the boundary (`_gather_recon`) or reshard
+  explicitly; stride only unsharded axes.
+- **GSPMD does not partition scatter.**  `jnp.histogram` AND a global `.at[idx].add` both lower with
+  all-gathers of the IMAGE-SIZED index/update arrays onto every device (47 GiB alloc on an ~18 GiB
+  sharded recon).  For sum-decomposable reductions with small outputs, enforce the decomposition:
+  per-device LOCAL blocks (`image.addressable_shards`, deduped by `shard.index` — a replicated array
+  yields one identical shard per device), partials combined on the host
+  (`segmentation._sharded_histogram`).  `shard_map` also achieved 0 all-gathers in HLO but its SPMD
+  partitioner has produced pathological lowerings here (3–5× slower fbp filter; see
+  `experiments/sharding/parallel_performance/fbp_parallel_options.md`) — prefer the per-device
+  dispatch pattern (dispatch all work before reading any result and the devices overlap without
+  threads).
+- **The device form (padded arrays) is the INTERNAL contract; crop at user boundaries.**  Internal
+  sharded methods stay device-form (a non-dividing real count can't shard); user-facing methods
+  gather + crop (`_gather_recon`/`_gather_sinogram`).  Corollaries:
+  - Per-slice/per-view operations must anchor on the REAL count, not the padded shape (a bottom
+    margin at `[-b:]` zeroes padding instead of real slices; a per-slice weight built at the real
+    count crashes on the padded form — and a padded slice with coverage 0 turns `0 * inf` into NaN,
+    poisoning the inert padding).
+  - Padded entries must stay EXACTLY zero (the inertness spec); statistical reductions exclude them
+    via `Placement.real_mask(ndim)` (a tiny broadcastable host mask, None when unpadded).
+  - `jnp.ravel_multi_index` needs `mode='clip'` under jit (default `'raise'` demands concrete values).
+  - Latent device-form assumptions surface only at NON-dividing device counts — run tests at a count
+    that does not divide the axis; and build test arrays from the SAME model under test (a wrong-sized
+    real array can coincide with another model's padded form and be silently accepted).
+- **Sharded arrays leak via reference cycles — donate in-place state, `.delete()` eager transients.**
+  `NamedSharding` arrays sit in internal ref cycles and free only on cyclic GC (which ignores device
+  pressure), so out-of-place per-subset updates accumulate one full array per op (tell: peak grows
+  with iteration count while end-state `bytes_in_use` is small).  Donate the persistent state
+  (`donate_argnames`); `.delete()` one-shot eager transients after a single `block_until_ready`
+  (jit/`assemble_sharded` outputs free on refcount and need no delete).  **Before deleting an array
+  derived from a caller's, prove you allocated its buffers**: resharding can return a no-copy alias —
+  the ownership test is device-set disjointness (`set(x.devices()).isdisjoint(placement.devices)`),
+  not object identity.  Release aliases before donating or donation silently copies.
+- **Never create a pytree-typed class inside a function that feeds a jit static arg.**  A
+  `namedtuple(...)` call mints a new class per call; jit keys its static cache on the treedef (which
+  includes the class), so equal-valued params from two instances retrace (measured 16× first-call
+  cost).  Define/cache the class at module level (`ParameterHandler.make_geometry_params`).
+- **cuSolver-family calls (`jnp.linalg.solve/svd/eig/...`) on small systems → host `np.linalg`.**
+  Their workspaces allocate outside XLA's pool (see §7) and the async failure surfaces only at first
+  read.  (`jnp.linalg.norm` is pure XLA — fine, but jit it; see §7.)
+- **`lax.map(batch_size=…)` is unsafe for large batches (jax#27591)** — use `vmap` for parallelism
+  and scan without `batch_size`.
+- **A heterogeneous (CPU+GPU) mesh is fragile** — the hybrid mode is two separate single-device
+  meshes (one per placement), never one mixed mesh.
 
-## Phase D case study (back projection — reduce-scatter + streaming)
+## 4. The 2^31 / dtype boundary
 
-1. **View-sharding makes back projection a reduce-scatter, and it's
-   memory-bandwidth-bound.**  Each device back-projects its views onto the full
-   slice range; partials are summed to the slice owners.  On CPU it caps at
-   ~1.5× (the virtual devices share one memory bus — a bandwidth limit, not a
-   core limit), while the *same harness* scales `fbp_filter` ~7× (compute-bound).
-   On GPU, where each device has its own HBM, it scales near-ideal (3.92× on 4).
-   **Bandwidth-bound ops scale on real per-device hardware, not virtual CPU
-   devices** — don't chase CPU scaling for them.
-2. **Attribute the bottleneck with a phase ablation.**  Timing the per-device
-   compute vs the reduce-scatter *separately* showed the cap was the compute
-   (bandwidth); the reduce-scatter was ≤9%, so comms optimizations were a dead
-   end.  A single-variable ablation beats guessing (cf. F1's jit-toggle).
-3. **Balanced tiling, NOT the F1 overlapping tail.**  F1's overlapping-window
-   tail is right when the per-unit work is a cheap, idempotent row filter.  A
-   back-projection band is an *expensive projector call*, so an overlapping tail
-   nearly doubles a band's compute (130 slices, B=128 → recompute 126).  Use
-   balanced equal bands (zero recompute).  Same ragged-tail problem, opposite
-   answer, because the cost structure flipped.
-4. **The band length must be device- AND compute-aware.**  The owner's reduce
-   gather is `n_dev × num_pixels × band`, so band must shrink with `n_dev` (a
-   per-owner-sized band re-gathers the whole cylinder).  A separate *compute*
-   working-set bound (n_dev-independent) is what makes a **single** device
-   stream; plus a per-band-work floor so small recons don't over-split into tiny
-   dispatches.  On GPU, time was flat across band sizes → **smaller band = free
-   memory** (single-GPU 1024³: 28 → ~12 GB at no time cost).
-5. **Don't port a trick without confirming the *cause* — the in-place-assembly
-   miss.**  We assumed the single-device memory plateau (~1.44× the sino+recon
-   floor) was the per-owner `jnp.concatenate(band_list)` doubling, and ported the
-   F1 in-place donated `dynamic_update_slice`.  Measurement showed peak got
-   *worse* everywhere (1024³/4-dev +41%): the concatenate was never the binding
-   peak (it runs after the compute phase).  **Reverted.**  Corollaries: a clean
-   CPU "no donation warning" did NOT predict the GPU memory result — measure on
-   the target; confirm a plateau's cause before optimizing it.
-6. **Reuse what the kernel already does.**  Parallel-beam back projection needed
-   only a one-line kernel fix (size the voxel cylinder from the *input* rows, not
-   `projector_params`) so a row-sliced view yields just those slices — the whole
-   streaming scheme then reused the existing jitted projector unchanged.
+A full-size sinogram/recon (~4.6–4.8e9 elements) crosses int32's 2^31 ≈ 2.1e9; with jax x64 disabled
+several mechanisms fail there, mostly SILENTLY.  Treat any element COUNT or FLAT INDEX at this scale
+as suspect — and note small phantoms can never reproduce these (size-dependent, not path-dependent).
 
-## Placement architecture + GPU-allocation reliability (2026-06-03)
+1. **`jnp/lax.argmin` over a >2^31-element array WRAPS with no warning** (index labels are int32
+   regardless of axis length; a min planted at 2.3e9 returned −1,994,967,296 = off by exactly 2^32).
+   A scalar read on a >2^31 flat axis separately requests int64 indices, truncated with the
+   "int64 ... truncated to int32" UserWarning — the warning is smoke from the read; the fire is the
+   argmin.  Fix: never form flat indices on full-size arrays — stage the argmin per axis and carry
+   `(view, row, col)` tuples with basic per-axis indexing (`mar._argmin_3d`).
+2. **A Python int > 2^31 as a traced operand raises OverflowError at the jit boundary** (weak int →
+   int32).  Counts enter traced arithmetic as FLOATS (`float(n)`; same ~1e-7 rounding `jnp.mean` had
+   internally); per-run int counts passed to jitted functions are STATIC args, float()ed in the body.
+3. **`np.prod` of a shape accumulates in the platform default int** — int64 on Linux/macOS, int32 on
+   Windows/numpy<2 (silent wrap).  Use `math.prod` for element counts.
+4. **Integer counting: int32 wraps above 2^31, and f32 scatter-adds of unit counts SATURATE at 2^24**
+   (ulp > 1 → +1 rounds to +0; silent undercount).  Count in slabs < 2^31 (int32 exact within a slab)
+   and accumulate in int64 on the host (`_sharded_histogram`).
+5. **A float64 scalar promotes the whole array** (`f32_array * np.pi` → f64, doubling memory).  Type
+   constants to the array dtype or fold them into a small f32 operand.
+6. **`np.histogram`'s bin edges depend on the DTYPE of `range`** (f32 scalars → f32-computed linspace;
+   python floats → f64-computed then cast; a few ULP apart).  Pass python floats everywhere for
+   cross-path edge consistency.
 
-The device-config redesign and the back-projection re-open under it.
+## 5. Measuring honestly (the ruler)
 
-1. **One placement abstraction, two roles.**  `recon_placement` / `sino_placement`
-   (each a device list + sharded axis + 1-D mesh) replace the scalar
-   `main_device` / `sinogram_device`.  Every mode is a placement pair; single
-   device is a trivial 1-shard placement, so sharding is "always on" and the
-   `mesh is None` branching dissolves.  The hybrid (recon-CPU / sino-GPU) case is
-   two *separate* single-device meshes — never one mixed mesh — which sidesteps
-   the JAX heterogeneous-mesh fragility.
-2. **The only thing that crosses placements is voxel cylinders.**  The sinogram
-   is written locally on its view-shard and never moves.  So the whole inter-
-   device interface is one adjoint pair — `move_cylinders_to_sino` (all-gather)
-   / `sum_cylinders_to_recon` (reduce-scatter) — built on `move_shard`, looping
-   over the placements' shards: `N×N` homogeneous, `1×1` single-device, **no
-   mode branch**.  Take cylinders directly (the pixel axis is unsharded, so the
-   caller slices `flat_recon[pix]`); keeps the primitives pure + unit-testable.
-3. **User-facing = match input; internal = sharded-only.**  User-facing methods
-   (`back_project`, `fbp_recon`, `direct_recon`, future `forward_project`) match
-   their input: plain in → plain out (shard at entry, gather at exit), sharded in
-   → sharded out (no gather).  Internal (`sparse_*`, `fbp_filter`/`direct_filter`)
-   are sharded in → sharded out, no transition code.  Decided by one
-   `isinstance(x.sharding, NamedSharding)` on the primary input, read *before* the
-   entry shard.  Why match-input not always-gather: these are dual-use
-   (`direct_recon` is `vcd_recon`'s init), so a sharded caller stays on-device.
-4. **Pixel-batch vs slice-band back projection — fine grain is fragile.**  The
-   slice-banded path fires ~n_dev² × bands small dispatches; the pixel-batched
-   path (full cylinders per pixel batch, reduce-scattered) fires far fewer,
-   larger ops.  On a clean H100×3 run the pixel path scaled *as-well-or-better*
-   (1008³: 3.12× vs 2.75× on 3 dev) but used ~2–2.7× more memory at the default
-   B_p; the band path is memory-lean but dispatch-heavy (which also made it more
-   sensitive to the NUMA/throttle issues below).  **Verdict (2026-06-03): kept
-   band, removed pixel.**  The B_p sweep showed pixel's memory plateaus at
-   ~1.7–2.7× band — a floor B_p can't push below (it's the accumulated output +
-   concatenate, not the per-batch transient) — for only ~11–16% less time.  With
-   memory / max-recon-per-GPU the priority, that gap isn't worth pixel's
-   simplicity/speed.  (The genuinely simpler *and* memory-lean option for parallel
-   beam is the slice-sharded-sinogram / embarrassingly-parallel scheme, noted as a
-   future option — not pixel.)
+- **`peak_bytes_in_use` is a process-cumulative high-water mark of LIVE bytes.**  It never resets, so
+  honest per-config memory needs a fresh subprocess per config, with a JAX-free orchestrator.  It is
+  preallocation-INVARIANT (it tracks in-use tensors, not the pool), so `PREALLOCATE=false` does NOT
+  reveal the capacity floor — to find the true OOM threshold, keep preallocation and LOWER
+  `XLA_PYTHON_CLIENT_MEM_FRACTION` so XLA rematerializes to fit.  For out-of-pool starvation the
+  right ruler is `pool_bytes`/`peak_pool_bytes` (the retained reservation), not `bytes_in_use` (§7).
+- **Timing hygiene:** free the previous result inside a timing loop (holding it over-reports a full
+  shard and causes allocation thrash); feed already-on-device inputs so you measure the op, not a
+  host transfer (a fresh-host-input lambda turned a 2.25× kernel gap into a bogus 1.45×); label
+  every number first-call (trace+compile) vs warm; per-call timing in one process is the clean
+  instrument; don't keep two full models alive per size (swap masquerades as a cliff).
+- **An OOM can surface as an unrelated-looking error** — classify from the FULL traceback
+  (`traceback.format_exc()`), and never let a harness truncate `str(e)`.
+- **A throttling GPU masquerades as a code regression.**  Signature: size-dependent (sustained load
+  only) AND device-count-specific (only when the bad card joins).  Discriminator: low clock AND high
+  temp (345 MHz alone is the H100 idle clock); the warmest-at-idle card is the culprit — a 10 s
+  `nvidia-smi dmon` is a cheap preflight.  The scaling harness self-records topo/UUIDs/clock+temp and
+  flags `[THROTTLED]` rows.
+- **An op- and platform-specific slowdown with sibling ops flat is a TOOLCHAIN regression — bisect
+  the jax version, not your diff.**  (jaxlib 0.10.2 regressed the forward GEMM path 3–9× while back/
+  filter were byte-identical; 0.10.1 is the pin.)  Playbook: pin the code, downgrade jax one release
+  at a time; `tooling/scaling_tests/measure_one_cell.py` reproduces one cell in ~30 s and prints
+  `toolchain_info()`; the `toolchain` field in each regression YAML makes the next drift a one-line
+  diff.  Re-baseline deliberately on any jax bump.
+- **When GPU behavior contradicts local tests, verify the BUILD first.**  Editable installs can serve
+  stale compiled state (a "33 GB leak" was a stale binary); and a modern `pip install -e` registers a
+  `sys.meta_path` finder that beats `PYTHONPATH` — to select code under test, install it into a
+  dedicated env (`mbirjax_metrics/tooling/regression/lib_env.sh`), never point `PYTHONPATH` at it.
 
-5. **A throttling GPU masqueraded as a code regression — separate the ruler from
-   the measured, hardware edition.**  Band 4-device at 1024³ "regressed" 2.8× vs
-   a prior run — but the *same Phase D commit* reproduced it, so it wasn't code.
-   The tell-tale signature: **size-dependent (only the largest, sustained load)
-   and device-count-specific (only when the bad card joined).**  The phase
-   ablation isolated it to Phase 1 (compute), not the reduce-scatter (≤0.2%).
-   Root cause via `nvidia-smi dmon`: one GPU at **345 MHz @ 86 °C** while its
-   neighbors ran **1980 MHz @ 40 °C** — a thermally-throttling card; the reduce
-   waits for the slowest device, so it gated the whole multi-device run.
-   - **Idle temperature predicts it:** the warmest-at-idle card (61 °C vs ~30 °C)
-     was the one that throttled.  A 10-second `dmon` glance is a cheap pre-flight.
-   - **345 MHz alone is NOT throttling** — it's the normal H100 *idle* clock; the
-     discriminator is low clock AND high temp (vs low clock + cool = idle).
-   - **`DEVICE_COUNTS = [1,2,3]`** sidesteps a known-bad 4th slot (`pick_devices`
-     takes the first n) and, on a 2/2-NUMA node, also keeps all three on one
-     socket — so 3-on-one-socket is often the cleanest scaling a node can give.
-6. **Instrument the ruler.**  The scaling harness now self-records, per run:
-   `nvidia-smi topo -m` + GPU UUIDs (allocation/NUMA), `dev2dev_safe` (host-bounce
-   state), and a per-GPU clock/temp sample that flags a row `[THROTTLED]` when a
-   participating GPU shows the low-clock+high-temp signature.  Turns this whole
-   class of afternoon-eating surprise into a one-line annotation in the result.
-7. **Gitignored `results/` doesn't survive a handoff.**  Scaling numbers and the
-   decisions they drive must be written into committed prose (status / plan /
-   here), or they evaporate with the session.
+## 6. Performance expectations
 
-## Sharded VCD memory: jax reference cycles + buffer donation (2026-06-07)
+- **Projection time ∝ N⁴ (voxels × views); memory ∝ N³.**  Ideal curves for size sweeps must use
+  these, not a common exponent.
+- **On GPU, sharding is primarily a CAPACITY tool; speed is the bonus above the crossover.**  Read
+  whether memory shards (it does) before judging time.  Back projection is NON-monotonic in devices
+  (the band kernel's GPU cost): n≥3 before sharded back wins on time — but VCD stays monotonic
+  because the forward masks it.
+- **Platform-divergent kernels are real; platform-gated selection is legitimate.**  The band back
+  kernel is ~8× faster than the pixel kernel on CPU (fusion-barrier cache cliff) and 2.25× slower on
+  GPU — hence the GPU-only n=1 short-circuit to the pixel kernel.
+- **CPU sharding is a real speedup for compute-bound ops (~5–6× on the filter — users run on CPU),
+  but bandwidth-bound ops (back projection) cap ~1.5× on virtual CPU devices** (shared memory bus)
+  while scaling near-ideal on real per-device GPU HBM.  ~4 devices is the CPU sweet spot; 8 regresses.
+- **VCD has a problem-SIZE floor — never judge sharding below ~256³.**  It calls the projectors on
+  `pixels/num_subsets` per update, so per-op work is num_subsets× smaller than a bare projection; toy
+  sizes show "slowdowns" that are the size, not a defect.  Its per-subset host scalar syncs (the
+  line-search alpha) are the GPU-specific limiter; the sharded qGGMRF prior regresses at fine
+  granularity (small share of cost — optimize only if the prior ever dominates).
 
-The 1-device-mesh / multi-GPU VCD "memory blowup" (504³/5-iter peaked 25.8 GB vs
-6.9 GB single-device; OOM at 1008³) was **not** the band, not pixel-batching, not
-async run-ahead — it was object lifecycle.
+## 7. Out-of-pool GPU allocations
 
-- **jax holds sharded (`NamedSharding`) arrays in internal reference cycles** (an
-  `ArrayImpl`'s `__dict__` references its sharding/buffers with back-refs), so they are
-  reclaimed only by the **cyclic GC**, not by refcounting.  Single-device
-  (`SingleDeviceSharding`) arrays free on refcount-0 normally.  So any per-subset (or
-  per-iteration) **out-of-place** update producing a *new* sharded array leaves the
-  stale one alive until a GC runs — and Python's GC is unaware of device-memory pressure
-  (it triggers on object counts), so they accumulate one full array per operation.  Peak
-  grew with #subset-updates (subsets × passes); `bytes_in_use` at the end was tiny
-  (gc-pending) — the tell-tale signature.
-- **Fix = donate for in-place state, `.delete()` for transients.**  Update the
-  persistent state in place via buffer donation —
-  `@partial(jax.jit, donate_argnames='error_sinogram')` returning
-  `error_sinogram - scaled_delta` — exactly as `update_recon` already did for the recon
-  (that recon-vs-sino asymmetry, recon flat / sino leaking, was the diagnostic tell).
-  Explicitly `.delete()` the one-shot **eager-op** transients (the `alpha*delta` scale,
-  the `weights*error` product).  **Forward-projection outputs (from `assemble_sharded` /
-  `make_array_from_single_device_arrays`) free on refcount** and need no delete — the
-  cycle is specific to eager elementwise-op outputs.  Result: peak flat at the
-  single-device floor (const 6.9, non-const 7.9, positivity 7.3 GB), time unchanged,
-  per-device memory still shards 1/n_dev (1008³ 1d→4d **4.49×** super-linear —
-  bandwidth-bound op + smaller per-device working set).
-- **Keep the scale eager (don't fold it into the donated jit).**  Folding to
-  `error - alpha*delta` lets XLA emit a fused multiply-add → last-bit difference →
-  breaks the trivial-mesh bit-exactness test.  A lone subtract can't be FMA-fused.
-  **UPDATE (step-4 Option B):** trivial-mesh is *not* bit-exact on GPU anyway — the
-  banded sharded path reorders non-associative FP sums vs the monolithic single-device
-  kernel, so a ~1 ULP difference is inherent (CPU compiles both identically, so it was
-  exact only there).  We therefore **relaxed the trivial-mesh tests to a tight `allclose`**
-  (1e-5 single-shot / 1e-4 iterated) and will **fold `alpha` back into the donated FMA**
-  during the unification, dropping the separate `scaled_delta` transient + its `.delete()`.
-  Lesson: "bit-exact across two differently-compiled kernels" is the wrong invariant on
-  GPU; use a tight tolerance and reserve exact-equality for same-kernel / data-movement
-  identities.
-  **RE-LEARNED 2026-06-11 (settable view params), then settled as a PROJECT RULE (Greg):
-  exact equality is NEVER the right gate for COMPUTED floats.**  Not across two models
-  (separate executables even for identical programs/shapes; GPU autotuning differs ~1 ULP),
-  and not even for one executable run twice (GPU scatter-add atomics reorder summation).
-  CPU happens to compile/run deterministically, so a bit-exact test written and passed on
-  CPU is exactly the kind that fails first on the GPU suite.  Gate computed floats at the
-  suite's single-shot 1e-5 (a genuinely wrong/stale value misses by orders of magnitude).
-  MEASURED calibration (2xH100, 2026-06-11): same-executable run-to-run GPU noise on the
-  forward projector reached ~8e-6 RELATIVE (~70 ULP; scatter-add atomics reorder hundreds
-  of per-detector-element contributions) — so 1e-6 is TOO TIGHT for anything touching the
-  projectors; pure elementwise kernels (qGGMRF cylinder) are safe at 1e-6.  Exact equality
-  remains correct for exactly two things: (1) DATA MOVEMENT
-  identities (shard/gather/assemble round trips, halo extraction, stored-parameter echo —
-  bytes in = bytes out, no arithmetic; a tolerance would mask corruption), and
-  (2) CONSTRUCTED-ZERO invariants (padded entries == 0.0 — the "exactly inert" spec;
-  allclose would hide a leak into the padding, the precise failure the invariant exists
-  to catch).
-- **Scale-invariant tolerances for sharded-vs-single comparisons (2026-06-19, translation T4).**
-  Two refinements to the rule above, both surfaced by a translation Hessian test that "failed"
-  at the suite's flat `rtol=atol=1e-5`:
-  - **Even CPU is not deterministic ACROSS PROCESSES for the reduce-scatter sum.**  The earlier
-    "CPU compiles both identically and stays exact" (above) holds only WITHIN one process.
-    MEASURED: the sharded-vs-single back/Hessian difference on CPU is usually EXACTLY 0 but
-    occasionally ~1e-7 of the peak — and IDENTICAL across device counts (n=2 == n=4) within a
-    process, so it is a per-PROCESS XLA reduction-ORDER / autotuning choice, not per-call
-    scatter-add reorder.  Consequence: a sharded-comparison test can FLAKE process-to-process on
-    CPU, not just "fail first on the GPU suite."  So the bit-exact-on-CPU assumption is wrong for
-    anything crossing a reduce-scatter / all-gather.
-  - **A fixed `atol` is a scale-dependent ruler; gate on a scale-invariant relative-max.**  The
-    reduce-scatter noise scales with the PEAK magnitude (~1e-7 of it), so a fixed `atol=1e-5`
-    silently PASSES a small-magnitude operator (cone Hessian peak ~1.8 → noise ~2e-7 ≪ atol) and
-    FALSE-FAILS / flakes a large-magnitude one (translation Hessian peak ~5e3 → noise ~5e-4 ≫
-    atol) for the SAME relative noise.  `coeff_power=2` (Hessian) squares the coefficients → the
-    largest peak → hit first.  This was a RULER bug, not a sharding error: cone and translation
-    had the same relative noise AND the same fraction of near-zero entries; only the value SCALE
-    differed.  Fix = gate on `max|out-ref| / max|ref| ≤ TOL` (the shared `tests/sharding/
-    conftest.rel_max_err`).  NOT a per-element `rtol` (atol=0): that divides by each element's
-    OWN value, so a near-zero entry — whose noise comes from the large terms that cancelled —
-    gets a near-zero threshold and the relative diff explodes.  The shared gate is
-    `conftest.assert_sharded_allclose`, used for every sharded-vs-single comparison in the
-    sharding suite; exact equality / `assert_array_equal` stays for data-movement and
-    constructed-zero invariants, and the 1e-6 elementwise qGGMRF kernel band tests keep their
-    tight gate (no reduce-scatter, so the peak-scaled noise does not apply).
-- **Donation-engagement gotchas.**  (a) Release aliases first: for constant weights
-  `weighted_error_sinogram IS error_sinogram`, so `= None` it or donation silently falls
-  back to a copy.  (b) Donating 2 inputs for 1 output warns "Some donated buffers were
-  not usable" — benign (surplus still freed) but noisy; donate only the in-place state
-  and `.delete()` the transient to avoid it.  (c) Bare `.delete()` of an array still
-  feeding a pending op risks a silent race — gate it behind one `block_until_ready` on
-  the returned state (every transient is upstream of it).  Consolidate all frees into one
-  end-of-subset cleanup section after that single block.  (d) **Identity ≠ buffer-ownership
-  when freeing a PASSED-IN array.**  Freeing the init-phase sinogram in `vcd_recon` (2026-06-25,
-  ~4 GiB/shard reclaimed before the Hessian + loop) first guarded on object identity
-  (`placed is not original`) — and broke 4 sweep tests with `RuntimeError: Array has been
-  deleted`.  Cause: `device_put`/`move_shard` can return a **no-copy reshard** — a *different*
-  `ArrayImpl` that *shares the same device buffers* as the input — when the data already lives on
-  the target devices (and `_shard_on_axis` returns the input UNCHANGED on an exact-sharding match).
-  So `.delete()` on the "new" object frees the caller's buffers (the caller, e.g. a `recon` sweep
-  or `prepare_sino_for_devices`, then re-reads a deleted array).  Correct ownership test: we own
-  fresh buffers iff `to_sino` had to TRANSFER the data — host/numpy input, or a jax array whose
-  devices are **disjoint** from the placement's devices (`set(x.devices()).isdisjoint(placement.
-  devices)`).  An input already resident on (any of) the placement devices may alias → do NOT
-  delete.  General rule: before deleting an array derived from a caller-supplied one, prove you
-  allocated its buffers (a cross-device/host transfer), not just that you hold a distinct handle.
-- **`@jax.jit` defeats the host-preserving `xp` pattern (2026-06-28, export OOM fix).**  The
-  host-transparency trick `xp = jnp if isinstance(x, jax.Array) else np` (used in `gen_weights`,
-  `stitch_arrays`, `generate_demo_data`) only works EAGERLY.  If the function is `@jax.jit`-decorated,
-  jit always returns a device array AND traces the input (the arg is a Tracer, not a host ndarray), so
-  the `xp` branch is INERT and the whole input is shipped to one device.  `apply_cylindrical_mask` was
-  jitted; the `xp` edit looked right but a host recon still went to gpu0 (the export-time OOM persisted)
-  until the **jit decorator was removed** (it's a one-shot post-recon mask, not a hot path).  Rule: to
-  make a function host-preserving, it must run eagerly — a jitted function can't be; either de-jit it
-  (fine for non-hot ops) or branch BEFORE the jit boundary.  Tell: `inspect.getsourcefile(fn)` raises
-  "got PjitFunction" and the output is a jax array for a numpy input.
-- **Diagnostic method that cracked it.**  A per-subset/per-iteration `peak_bytes_in_use`
-  "memjump" trace showed the view-sharded-sino count climbing 1/op; `gc.get_referrers`
-  named the holder (`ArrayImpl.__dict__`); an explicit `gc.collect()` dropped `live_end`
-  to one volume (proving gc-pending cycles).  Pitfalls: a too-short config
-  (`MAX_ITERATIONS=1`) hid the per-iteration accumulation — the *mesh* peak GROWS with
-  iterations (only single-device reaches peak early), suspect the ruler; and
-  `gc.get_referrers` can itself pin objects, confounding a GC-frequency test.
-- **STALE BUILD chimera.**  A reported 33.4 GB "non-constant-weights leak" was a stale
-  GPU binary running the pre-fix code; a fresh `pip install -e .` made it bounded (7.9
-  GB).  When GPU memory/behavior contradicts the local tests, **verify the build first**
-  (editable installs can serve stale compiled state) — it cost a diagnosis detour.
-- **Scaling model (size sweep).**  Projection **time ∝ N⁴ (voxels × views)** — each
-  voxel projects to each view — while **memory ∝ N³ (voxels)** (resident sino+recon).
-  Doubling linear size is ×16 time but only ×8 memory; the size-sweep TIME ideal curve
-  must scale as voxels·views, the MEMORY ideal as voxels.
-- **`is_sharded` over `self.mesh is not None`.**  A single `@property` (body
-  `self.mesh is not None` now, placement-based later) is the one place to change at the
-  mesh→placement migration and the one thing to retire once all geometries shard.  The
-  transient-free **cleanup section does NOT retire at unification** — it's inherent to
-  host-orchestrated sharded arrays (the reference cycle above); only the *guards* go away.
-- **`namedtuple()` inside a function silently defeats jit static-arg cache sharing
-  across instances.**  jax registers namedtuples as PYTREES and keys the jit
-  static-argument cache on the pytree TREEDEF — which includes the namedtuple CLASS.
-  `namedtuple('GeometryParams', names)` called inside `get_geometry_parameters` mints a
-  NEW class every call, so two model instances with byte-identical params get DIFFERENT
-  treedefs (`tree_flatten(p1).treedef != …p2`) and a shared module-level jit RE-TRACES per
-  instance — *even though the params are `==` and hash-equal* (jit compares the treedef
-  first and never reaches the value compare).  Symptom: `_jit_fn._cache_size()` grows by
-  one per fresh same-geometry instance; the 2nd model's first call pays full trace+compile
-  (measured **16× slower**: 201→13 ms once shared).  FIX: build the namedtuple CLASS once
-  (cache it by field-name tuple — `ParameterHandler.make_geometry_params`) so the treedef
-  is stable.  The diagnostic that cracked it: a `_replace()` copy (same nested field
-  objects) HIT the cache while an `==`-but-fresh copy MISSED ⇒ the key is identity-of-type,
-  not value.  General rule: **never create a pytree-typed object (namedtuple / custom
-  registered node) inside a function that feeds a jit STATIC arg — define the type at
-  module level.**  (Also why de-closuring alone did not share the cache until the
-  namedtuple classes were hoisted.)
+With a near-total BFC reservation, everything allocating OUTSIDE XLA's pool shares the small
+remainder — and the pool RETAINS its high-water mark for the life of the process, so late
+out-of-pool allocations starve even on an "idle" GPU.  Two sub-classes:
 
-## Platform-divergent back-projection kernel → n=1 GPU short-circuit (2026-06-16)
+1. **cuSolver-family workspaces** fail (`gpusolverDnCreate ... cuSolver internal error`) even with
+   the pool mostly free; the ASYNC dispatch surfaces the error only when the result is first read.
+   Policy: small systems solve on the host (§3).
+2. **NCCL/collective buffers** (`cuda_vmm allocator ... RESOURCE_EXHAUSTED`): any eager op on a
+   SHARDED array that reduces cross-device allocates collective buffers outside the pool, one set per
+   separate executable — per-iteration eager stats multiply the exposure.  Policy: one jitted stats
+   function (§3).
 
-Cone `back` on ONE device was +126–136% slower than `main` on GPU (propagating to cone
-VCD).  Bisecting it produced a clean, surprising result: **the two cone back kernels have
-OPPOSITE platform rankings, the sharded driver is free, and the right fix is
-platform-gated kernel selection.**
+Diagnostics: check `pool_bytes` (retained reservation), not `bytes_in_use`; the confirming ablation
+is lowering the mem fraction.  Confirmed on the cluster: `bytes_in_use` 0.64 GB with `pool_bytes`
+83.3 GB at the failure point; 0.94 cleared it.  FIXED: `tomography_model.py` uses
+`os.environ.setdefault('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.94')` — conservative headroom,
+overridable per-run via the environment (it was a hard-set '0.98' the env var could not override).
 
-- **The cost is the KERNEL, not the sharded driver.**  Driver-less ablation (call the
-  projector functions directly, no thread pool / reduce-scatter / `assemble_sharded`): a
-  band-loop tied the FULL sharded path at **1.00× time and 1.00× memory** at n=1.  So all
-  the n=1 overhead is the per-view kernel: `back_project_one_view_to_band` (single vertical
-  fan) vs `back_project_one_view_to_pixel_batch` (rolled `lax.map`@128 + transpose).
-- **Opposite platform rankings (no kernel wins both).**  Driver-less, same batch sizes,
-  same inputs, 512³: GPU — band kernel **2.25× SLOWER** than the pixel/rolled kernel; CPU —
-  band kernel **~8× FASTER**.  On CPU the pixel kernel hits the documented back-vertical
-  cache cliff (×62/×110 at ≥~200³): the `lax.map`+transpose UNDER the view-`vmap` is a
-  fusion barrier → XLA materializes the full `(views × npix × slices)` per-view stack →
-  cache-thrash.  It is WARM execution (call-1 ≈ call-N; compile ~0.4 s), and **band-size
-  independent** (B128 ≈ Bmono), i.e. the `lax.map` itself, not the band length.  The band
-  kernel (no `lax.map`/transpose) keeps the `vmap+sum` fused → no cliff.
-- **Fix: GPU-only n=1 short-circuit** (`_sparse_back_project_sharded`): a single-GPU mesh
-  routes to `_sparse_back_project_single_device` (the pixel kernel) and wraps its output as
-  a 1-shard slice-sharded array (`assemble_sharded`, metadata only — validated bit-identical
-  + same sharding to the band path).  Gated on `recon_placement.devices[0].platform == 'gpu'`
-  (the codebase's GPU test, tomography_model ~247) AND `view_indices is None`.  CPU keeps the
-  band path (cliff-avoidance).  Net = **pixel kernel on GPU, band kernel on CPU** = the
-  platform-optimal choice.  NOT a clean mirror of the forward n=1 fix: forward's single-call
-  was win-win (time + memory); back's is a time win that gives up only the *bonus* capacity.
-- **Memory: the band kernel streams (capacity), the pixel kernel doesn't.**  At 1024³ the
-  `MAX_BAND_WORK` cap makes the band path stream the slice axis → peak **12.5 GB vs 21 GB**
-  for the pixel path.  But the pixel path's peak **= main's exactly** (B-back ≤ main-back at
-  every size), so GPU→B matches main's single-GPU capacity (which does 1024³); it forfeits
-  only the banding *bonus* headroom over main.  Watch VCD capacity via the perf-tracking tool
-  rather than gate on it.
-- **Ruler bug that hid all this for two sessions.**  The first A/B reported 1.45 and a
-  "+56% kernel residual"; both were a measurement artifact — B was timed with a FRESH HOST
-  sinogram built INSIDE the timing lambda, so it paid a host→device transfer every call.
-  Feeding the already-on-device sinogram (measure the op, not the scatter) gave A/B = **2.25**
-  and **B ≈ main (+1%)** — the kernel is GPU-NEUTRAL (vindicating the B2 claim), and the whole
-  penalty is the band kernel.  Also: an apparent "A2 (n=2) cliff / minutes-long compile" was a
-  HARNESS artifact (two full models alive per size → swap), not the code — per-call timing in
-  one process (call-1 = trace+compile, call-N = warm) is the clean instrument; use it to label
-  every number first-call vs warm.
-- **Multi-device consequence (GPU-confirmed, `run_performance_local.py`).**  Making n=1 the fast
-  pixel kernel makes the back-projection device curve NON-monotonic: n=2 (band kernel at 2.25/2 per
-  device) is SLOWER than n=1, with a crossover at **n≈2.25** — so you need **≥3 GPUs before sharding
-  back pays in TIME** (it always pays in MEMORY).  Confirmed: 512³ back n=1/n=2/n=4 = 648/741/355 ms.
-  At the WORKLOAD level VCD stays monotonic (n=2 1.18–1.26×, n=4 ~2.0–2.1×) because the parallel
-  forward masks the back crossover — so the short-circuit is a clean VCD win (faster n=1, scaling
-  intact).  **Capacity:** n=1 1024³ nonc VCD = **74 GiB** (fits a ~79 GiB H100, ~5 GiB margin) ≈ main;
-  the band path's ~10 GiB n=1 headroom is given up, so single-GPU is effectively capped ~1024³ and
-  >1024³ uses n≥2 (DECISION (a): keep the simple short-circuit; sharding is the capacity tool, the
-  memory-aware pixel-vs-band-by-fit variant was deferred).  **The band kernel's GPU cost is now the
-  limiter of multi-device back scaling — the real B4.5 lever** (make the band kernel GPU-competitive,
-  e.g. a rolled/pixel-like internal structure, WITHOUT reintroducing the CPU cliff).
+## 8. Known-benign warnings
 
-## Exactly-inert cone slice padding (B5) + device-form footguns (2026-06-18)
+- **`cuda_vmm_allocator ... FABRIC+POSIX_FD ... CUDA_ERROR_NOT_PERMITTED ... will retry with simpler
+  handle types`** (W-level): the VMM allocator probing advanced handle types and falling back —
+  benign, verified correct results.  Silence with `TF_CPP_MIN_LOG_LEVEL=2`, which mbirjax sets at
+  import via `setdefault` — effective only if mbirjax (or the env var) precedes jax's initialization,
+  which is why some harness subprocesses still show it.  Distinguish W (warning) from E/F (real)
+  FIRST — this one was twice mis-chased.
+- **`cpu_aot_loader ... machine features don't match ... could lead to SIGILL`** (E-level, on cache
+  load): a stale persistent-compilation-cache entry (mbirjax enables `~/.mbirjax/jax_cache`) from a
+  different toolchain/node — or LLVM tuning attributes (`prefer-no-gather`) spuriously compared
+  against CPUID features.  A cache rebuild cleared it; results guarded by the metrics correctness
+  gates either way.
+- **`Some donated buffers were not usable`**: benign (surplus donations are still freed) — avoid the
+  noise by donating only the in-place state and `.delete()`ing transients.
 
-Turning on cone slice padding (a non-dividing slice count → zero-padded device form) was a
-small load-bearing fix plus several device-form contract subtleties.  The recurring theme:
-**a per-slice operation written for the REAL slice count silently breaks when handed the
-device-form (padded) array, and the failure mode depends on whether the wrong length crashes,
-contaminates, or NaNs.**
+## 9. Tooling / harness
 
-- **The forward gather must crop to the real slice count.**  Cone's sharded forward GATHERS the
-  full slice cylinder onto each view-owner and runs the MONOLITHIC kernel (decision C), which
-  anchors its slice→detector-row geometry on `recon_shape[2]` (REAL) and ASSERTS that length.
-  The gather assembled the device-form (padded) cylinder → shape assertion crash.  Fix:
-  `full_cyl = full_cyl[:, :recon_placement.real_size]` before the kernel.  EXACT because the
-  padded slices are zero (forced-zero invariant), so cropping them is identity on the result;
-  a no-op at dividing counts.  This is the cone analogue of the masks elsewhere — the one site
-  that makes the gather-forward inert.  (The BACK projector already handled padding: the banded
-  kernel's global clip `k_global < S_real` + `_mask_padded_slices`.)
-- **Keep internal sharded methods device-form; crop at the boundary.**  The instinct to "make
-  `sparse_back_project` return the real shape" is WRONG: the VCD loop and `output_sharded` need a
-  slice-shardable padded array, and a non-dividing real count (e.g. 14) cannot shard across 4
-  devices.  The device form is the internal contract; the USER-facing `back_project` gathers+crops.
-  Callers that want the real shape crop `[:, :num_real_slices]` themselves (the pad is inert zeros).
-- **Pre-sharding tests carry a LATENT device-form assumption — exposed only at a non-dividing
-  count.**  `verify_adjoint`/`verify_hessian` did `x = uniform(bp.shape)` then `reshape((-1,
-  real_slices))` and `AtAx.reshape(real_shape)` — fine when `bp` is real, a crash/garble when it is
-  device-form.  This is GEOMETRY-AGNOSTIC: parallel fails identically at 3 devices (40 slices → 42),
-  hidden only because 40 divides the usual 2/4.  Single-variable ablation (run the SAME test at a
-  device count that does NOT divide the axis) is the cheap way to surface these.  Corollary: pinning
-  the test to 1 device would have *masked* a real latent bug — fix the contract, don't dodge it.
-- **The back projector assumes padded views are ZERO — a hand-built device-form input can violate
-  it.**  `verify_adjoint` built a random `y` over the device-form sinogram (nonzero padded-view
-  tail).  Back-projecting that tail at the clamped padding angle contaminated `Aᵀy` (~3% adjoint
-  gap) — NOT a crash, a quiet numerical error, and only at view-padding counts.  Production never
-  hits it (entry placement zero-fills the tail).  Fix in the test: zero `y[real_views:]`.
-- **`helical_fdk_z_weight`: a per-slice weight built at the real count, applied to the device form.**
-  It already handled the SINOGRAM's view-padding (real `num_views`) but built the per-recon-slice
-  `z_weight` at `recon_shape[2]` (real, 11 for the small helical) and multiplied the device-form
-  (padded, 12) recon → broadcast crash.  Two-part fix: build `z_weight` over the recon's
-  device-form slice length with the z-anchor on the REAL count (the anchor rule), AND force the
-  weight to 0 on the padded slices — because an out-of-coverage padded slice has coverage 0 →
-  `num_views/0 = inf`, and `0 * inf = NaN` would poison the otherwise-inert zero padding.  No-op at
-  dividing counts (which is why helical passed in `test_cone_sharded`).
-- **Device-form-coincidence footgun in `_pad_shard_on_axis`.**  It treats an input whose sharded-axis
-  length already equals `padded_size` as ALREADY device-form (passes it through `_shard_on_axis`, no
-  zero-fill).  So feeding a wrong-sized REAL array whose length happens to coincide with the device
-  form (e.g. a 7-slice geometry's real recon = 8, equal to the n=2 padded form of a different
-  7-slice model) is silently accepted, and its "padding" slices keep their real (nonzero) values.
-  Bit me in a test (used the wrong model helper to build the recon).  Lesson: build test arrays from
-  the SAME model under test (`self._make_model()`, `model.get_params('recon_shape')`), and don't
-  hardcode a real slice count (helical ≠ num_det_rows) — read it from params.
-
-## Out-of-pool GPU allocations vs a near-total BFC reservation (2026-07-02)
-
-With `XLA_PYTHON_CLIENT_MEM_FRACTION=0.98`, everything that allocates OUTSIDE XLA's BFC pool has
-~1.5 GB to live in — and the pool RETAINS its high-water mark (`pool_bytes` stays at the process peak
-even when `bytes_in_use` returns to ~0), so late-in-the-run out-of-pool allocations starve even on an
-"idle" GPU.  Two distinct sub-classes, one diagnostic, one policy:
-
-1. **cuSolver-family** (`jnp.linalg.solve/svd/eig/cholesky/inv`): the library's handle/workspace is
-   allocated outside the pool and fails (`gpusolverDnCreate ... cuSolver internal error`) even with the
-   pool mostly free — and the dispatch is ASYNC, so the error surfaces only when the result is first
-   read, far from the call.  Policy: for small systems (e.g. the MAR 15×15 QP), gather to host and use
-   `np.linalg` (done in `_estimate_BH_model_params_using_OSQP`); for large ones, budget pool headroom.
-2. **NCCL/collective buffers** (`cuda_vmm allocator ... RESOURCE_EXHAUSTED`): any eager op on a SHARDED
-   array that reduces cross-device (even `jnp.linalg.norm`, which is pure XLA — no cuSolver) allocates
-   collective buffers via the vmm allocator, outside the pool.  Each SEPARATE eager op/executable can
-   carry its own collective allocation, so per-iteration eager stats (loss, norm, L1) multiply the
-   exposure.  Policy: jit the recon-loop statistics into ONE function (one executable, one set of
-   collective buffers, and the fusion also removes the full-size eager temps) — see
-   `_vcd_iteration_stats` / the jitted `get_forward_model_loss` / `_gen_huber_weights_kernel`.
-
-Related (2026-07-02, the full-size Otsu histogram OOM — 47 GiB alloc in `jit__sharded_histogram` on an
-~18 GiB sharded recon): **GSPMD does NOT partition scatter.**  Both `jnp.histogram` (searchsorted
-composition) and an explicit `zeros(nbins).at[idx].add(contrib)` lower with **all-gathers of the
-IMAGE-SIZED index/update arrays onto every device** (verified in HLO: `s32[full-shape] all-gather`).
-For sum-decomposable reductions with a small output (histograms, bincounts), enforce the decomposition
-EXPLICITLY.  Two workable constructions; we chose (b):
-(a) `shard_map` + local scatter + `lax.psum` — verified 0 all-gathers / temps = 2× shard on CPU HLO,
-    but rejected: shard_map's SPMD partitioner has produced pathological lowerings here before
-    (`experiments/sharding/parallel_performance/fbp_parallel_options.md`: 3–5× slower fbp filter,
-    1-dev ≈ 2-dev inside shard_map), and GPU behavior could not be verified locally.
-(b) **Per-device local blocks** (`image.addressable_shards` — dedupe by `shard.index`, since a
-    replicated array yields one identical shard per device) histogrammed on their own devices in
-    **≤2^28-element slabs** (int32 exact within a slab by construction; bounds the bucketize temps),
-    partials combined **on the host in int64** — exact at any scale WITHOUT jax x64, and zero
-    cross-device collectives (min/max combine on host too; dispatch all slabs before reading any so
-    devices overlap without threads).  Matches the codebase's thread/dispatch-per-device pattern.
-Related traps hit on the way: **f32 scatter-adds of unit counts SATURATE at 2^24** (ulp > 1 → +1 rounds
-to +0), so float histogram accumulation silently undercounts, and int32 wraps above 2^31 — a 4.8e9-voxel
-volume's zero-bin exceeds both; **`np.histogram`'s bin edges depend on the dtype of `range`** (f32
-scalars → f32-computed linspace; python floats → f64-computed then cast, differing by a few ULP) — pass
-python floats everywhere for cross-path edge consistency; and subsampling the volume (the statistical
-shortcut) was REJECTED here because the metal class can be sparse (Greg) — exact counts were affordable.
-
-Diagnostics: `bytes_in_use` is the WRONG ruler for this class — check `pool_bytes`/`peak_pool_bytes`
-(the retained reservation) at the failure point; the confirming ablation is lowering the mem fraction.
-CONFIRMED on the cluster 2026-07-02: at the norm-OOM point `bytes_in_use` = 0.64 GB while `pool_bytes`
-= 83.3 GB (the full reservation), and fraction 0.94 eliminated the OOM.  FIXED: `tomography_model.py`
-now uses `os.environ.setdefault('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.94')` — a conservative default
-with out-of-pool headroom, overridable per-run via the environment (it was a hard-set '0.98' that the
-env var could not override).
-
-## The 2^31 scale boundary: silent int32 traps at full-size volumes (2026-07-03)
-
-A full-size sinogram/recon (~4.6–4.8e9 elements) crosses int32's 2^31 ≈ 2.1e9 limit, and with jax x64
-disabled, several independent mechanisms fail there — mostly SILENTLY.  Found one by one while tracing
-the full-size MAR recon; treat any element COUNT or FLAT INDEX at this scale as suspect.
-
-1. **`jnp/lax.argmin` over a >2^31-element array WRAPS, with no warning.**  Its index labels are
-   int32 (x64 off) regardless of axis length; a minimum planted at flat position 2.3e9 returned
-   −1,994,967,296 — off by exactly 2^32 — and the subsequent read silently fetched a wrong pixel.
-   The only visible symptom, sometimes, is downstream: a scalar read on a >2^31-long flat axis makes
-   jax request int64 indices (`int_dtype_for_dim`: int64 iff dim > int32_max), truncated with the
-   "Explicitly requested dtype int64 ... truncated to int32" UserWarning.  **The warning is smoke from
-   the read; the fire is the argmin.**  Small phantoms can NEVER reproduce it (int32 suffices) — the
-   failure is size-dependent, not path-dependent.  Fix: never form flat indices on full-size arrays —
-   stage the argmin per axis (per-view argmin over the R*C plane, then argmin over per-view minima;
-   identical row-major tie-breaking) and carry (view, row, col) tuples with basic per-axis indexing
-   (every axis << 2^31).  See `mar._argmin_3d`.
-2. **A Python int operand > 2^31 in a traced computation raises OverflowError at the jit boundary**
-   (weak int → int32): `error_sinogram.size` and `num_real_elements` in the fm-loss did this.  Fix:
-   counts enter traced arithmetic as FLOATS (`float(n)` — same ~1e-7 rounding jnp.mean had anyway),
-   and per-run int counts passed to jitted functions are STATIC args (a big static int used in traced
-   arithmetic must also be float()ed in the body).
-3. **`np.prod` of a shape accumulates in the platform default int** — int64 on Linux/macOS but int32
-   on Windows/numpy<2, where a full-size product silently wraps.  Use `math.prod` (exact Python ints)
-   for element counts.
-4. (From the histogram work, above:) int32 histogram counts wrap; **f32 scatter-adds of unit counts
-   SATURATE at 2^24** (+1 rounds to +0).  Count in slabs < 2^31 and accumulate in int64 on the host.
-
-## Tooling / harness
-
-- **A modern `pip install -e` overrides `PYTHONPATH` — prepending a checkout to `PYTHONPATH` does NOT
-  select it.**  Editable installs (setuptools ≥64 / PEP 660) register a `sys.meta_path` finder, which
-  Python consults BEFORE the `PYTHONPATH` path-finder, so `import mbirjax` resolves to the
-  editable-installed checkout regardless of `PYTHONPATH` (proven: a decoy `mbirjax` on `PYTHONPATH` was
-  ignored).  This silently bit the metrics harness' `add_run.sh` — it pointed the engine at a ref's
-  worktree via `PYTHONPATH` but measured whatever mbirjax was editable-installed in the active env (the
-  dev checkout), mislabeled as the ref.  To select code under test you must `pip install -e <worktree>`
-  into a DEDICATED env (re-points the finder) — never the user's dev env (deleting the worktree
-  afterward would break its install).  Shared now via `mbirjax_metrics/tooling/regression/lib_env.sh`.
-- **Seed any global-RNG partition creation before a cross-config comparison.**  `QGGMRFDenoiser.denoise`
-  builds its VCD pixel partitions with `np.random` (the library's own `test_denoiser.py` calls
-  `np.random.seed(0)` for this).  When the metrics harness first measured `denoise` across device counts,
-  the sharded-vs-n=1 fingerprint reldiff was ~1e-4 — 100× the ~1e-7 float floor and enough to false-trip
-  the gate — purely because each call drew DIFFERENT partitions.  Seeding `np.random` before each call
-  (now in `run_denoise`) collapsed it to ~1e-7: it isolates the dimension under test (device count) from
-  RNG variance, and also makes the fingerprint reproducible across runs/platforms (so vs-main /
-  cross-platform are meaningful).  General rule: if an op's result depends on a global RNG, fix the seed
-  or you are comparing noise.  (The projection `vcd_nonconst` avoids this by passing PRE-BUILT partitions.)
-- **uPlot's built-in log-axis tick generator can freeze for seconds on tight, non-power-of-10 bounds —
-  hand it your own splits.**  On a `distr:3` (log) axis whose scale min/max aren't round powers of ten
-  (e.g. a 6%-log-padded y-min of `9.76e-5`, just under `1e-4`), uPlot's splitter seeds its increment from
-  `pow(10, floor(log10(min)))`, then as it crosses the first decade boundary the increment degrades to a
-  tiny NON-power value whose internal decimal-places lookup misses — so it crawls the range in millions
-  of micro-steps, building a giant tick array.  Result: a ~2.5s main-thread freeze that leaves the panel
-  half-drawn (`axis._splits` null) — reads exactly like "the plot disappeared."  It surfaced only for the
-  GPU `parallel/back` TIME panel (a new `513³` run's timings happened to land the padded y-min in that
-  spot); CPU / other ops / linear axes were fine, which made it look purely data-specific.  It WAS
-  data-triggered, but the latent bug was the dashboard trusting uPlot's auto-splitter.  Tell: the X axis
-  never hung because it already passes custom `xSplits` (the size ticks), which bypasses the generator —
-  the Y axis didn't.  Fix: give yLog axes explicit ticks too — `logTicks(mn,mx)` = `1-9·10^k` within the
-  range (O(decades), bounded) — placed in the shared `linePlot` wrapper, so all four log panels (scaling
-  time+mem, history time+mem) inherit it; the X axes were already covered.  General rule: when ONE data
-  shape freezes a charting lib's log plot, suspect its auto-tick / auto-range generator and feed it
-  bounded ticks rather than massaging the data.  (Diagnosis aid: see [[dashboard-verify-gotchas]] — the
-  rAF-throttle trap nearly hid this, since uPlot defers its first draw to a `requestAnimationFrame`.)
-- **An op-specific, platform-specific slowdown with the sibling ops flat is a TOOLCHAIN regression —
-  bisect the jax version, not your diff.**  2026-06-27: GPU `forward` (and `vcd`, which calls it) ran
-  3–9× slower across EVERY geometry/size/device-count, while `back`/`direct_filter`/`denoise` were
-  byte-identical and CPU `forward` was unchanged.  The op-specificity (forward's GEMM-heavy kernels vs
-  back's custom scatter) + GPU-only pattern ruled out thermal throttling (SM/HBM clocks pinned at full
-  boost in both runs) AND the measured code.  The decisive ablation: checking out the fast mbirjax commit
-  **and** the matching `mbirjax_metrics` commit on the GPU STILL reproduced it ⇒ environment, not code.
-  A clean reinstall had bumped `jax`/`jaxlib` 0.10.1 → 0.10.2; downgrading ONLY those (CUDA 12.9 / cuDNN
-  92302 / cuBLAS 120900 unchanged) restored forward to 33.3 ms @ 200³ n=1 (from ~170 ms).  So jaxlib
-  0.10.2's XLA regressed the forward GEMM path.  Playbook: (1) op- + platform-specific with siblings flat
-  ⇒ suspect the compiler/runtime, not the code; (2) the cheap discriminator is to pin the code and
-  downgrade jax one release at a time (`pip install 'jax[cuda12]==<prev>' 'jaxlib==<prev>'`) and
-  re-measure; (3) `tooling/scaling_tests/measure_one_cell.py` reproduces ONE cell group in ~30 s for this
-  bisect, and prints `toolchain_info()` so the jax/CUDA/cuDNN/cuBLAS stack is on every line; (4) the
-  `toolchain` field is now in each regression YAML, so the NEXT drift is a one-line diff, not a multi-day
-  hunt.  Mitigation when it recurs: pin jax/jaxlib in the regression env for a stable mbirjax baseline (+
-  re-baseline deliberately on a bump), and report the upstream XLA regression.
+- **Gitignored `results/` does not survive a handoff** — numbers that drive decisions get written
+  into committed prose (status/plan/here), or they evaporate with the session.
+- **uPlot's log-axis auto-tick generator can freeze on tight non-power-of-10 bounds** — pass explicit
+  splits (`logTicks` in the shared `linePlot` wrapper); see the `dashboard-verify-gotchas` memory for
+  the full diagnosis pattern (rAF-throttle, probe synchronously).

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -593,6 +593,34 @@ now uses `os.environ.setdefault('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.94')` — a
 with out-of-pool headroom, overridable per-run via the environment (it was a hard-set '0.98' that the
 env var could not override).
 
+## The 2^31 scale boundary: silent int32 traps at full-size volumes (2026-07-03)
+
+A full-size sinogram/recon (~4.6–4.8e9 elements) crosses int32's 2^31 ≈ 2.1e9 limit, and with jax x64
+disabled, several independent mechanisms fail there — mostly SILENTLY.  Found one by one while tracing
+the full-size MAR recon; treat any element COUNT or FLAT INDEX at this scale as suspect.
+
+1. **`jnp/lax.argmin` over a >2^31-element array WRAPS, with no warning.**  Its index labels are
+   int32 (x64 off) regardless of axis length; a minimum planted at flat position 2.3e9 returned
+   −1,994,967,296 — off by exactly 2^32 — and the subsequent read silently fetched a wrong pixel.
+   The only visible symptom, sometimes, is downstream: a scalar read on a >2^31-long flat axis makes
+   jax request int64 indices (`int_dtype_for_dim`: int64 iff dim > int32_max), truncated with the
+   "Explicitly requested dtype int64 ... truncated to int32" UserWarning.  **The warning is smoke from
+   the read; the fire is the argmin.**  Small phantoms can NEVER reproduce it (int32 suffices) — the
+   failure is size-dependent, not path-dependent.  Fix: never form flat indices on full-size arrays —
+   stage the argmin per axis (per-view argmin over the R*C plane, then argmin over per-view minima;
+   identical row-major tie-breaking) and carry (view, row, col) tuples with basic per-axis indexing
+   (every axis << 2^31).  See `mar._argmin_3d`.
+2. **A Python int operand > 2^31 in a traced computation raises OverflowError at the jit boundary**
+   (weak int → int32): `error_sinogram.size` and `num_real_elements` in the fm-loss did this.  Fix:
+   counts enter traced arithmetic as FLOATS (`float(n)` — same ~1e-7 rounding jnp.mean had anyway),
+   and per-run int counts passed to jitted functions are STATIC args (a big static int used in traced
+   arithmetic must also be float()ed in the body).
+3. **`np.prod` of a shape accumulates in the platform default int** — int64 on Linux/macOS but int32
+   on Windows/numpy<2, where a full-size product silently wraps.  Use `math.prod` (exact Python ints)
+   for element counts.
+4. (From the histogram work, above:) int32 histogram counts wrap; **f32 scatter-adds of unit counts
+   SATURATE at 2^24** (+1 rounds to +0).  Count in slabs < 2^31 and accumulate in int64 on the host.
+
 ## Tooling / harness
 
 - **A modern `pip install -e` overrides `PYTHONPATH` — prepending a checkout to `PYTHONPATH` does NOT

--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -562,6 +562,29 @@ even when `bytes_in_use` returns to ~0), so late-in-the-run out-of-pool allocati
    collective buffers, and the fusion also removes the full-size eager temps) — see
    `_vcd_iteration_stats` / the jitted `get_forward_model_loss` / `_gen_huber_weights_kernel`.
 
+Related (2026-07-02, the full-size Otsu histogram OOM — 47 GiB alloc in `jit__sharded_histogram` on an
+~18 GiB sharded recon): **GSPMD does NOT partition scatter.**  Both `jnp.histogram` (searchsorted
+composition) and an explicit `zeros(nbins).at[idx].add(contrib)` lower with **all-gathers of the
+IMAGE-SIZED index/update arrays onto every device** (verified in HLO: `s32[full-shape] all-gather`).
+For sum-decomposable reductions with a small output (histograms, bincounts), enforce the decomposition
+EXPLICITLY.  Two workable constructions; we chose (b):
+(a) `shard_map` + local scatter + `lax.psum` — verified 0 all-gathers / temps = 2× shard on CPU HLO,
+    but rejected: shard_map's SPMD partitioner has produced pathological lowerings here before
+    (`experiments/sharding/parallel_performance/fbp_parallel_options.md`: 3–5× slower fbp filter,
+    1-dev ≈ 2-dev inside shard_map), and GPU behavior could not be verified locally.
+(b) **Per-device local blocks** (`image.addressable_shards` — dedupe by `shard.index`, since a
+    replicated array yields one identical shard per device) histogrammed on their own devices in
+    **≤2^28-element slabs** (int32 exact within a slab by construction; bounds the bucketize temps),
+    partials combined **on the host in int64** — exact at any scale WITHOUT jax x64, and zero
+    cross-device collectives (min/max combine on host too; dispatch all slabs before reading any so
+    devices overlap without threads).  Matches the codebase's thread/dispatch-per-device pattern.
+Related traps hit on the way: **f32 scatter-adds of unit counts SATURATE at 2^24** (ulp > 1 → +1 rounds
+to +0), so float histogram accumulation silently undercounts, and int32 wraps above 2^31 — a 4.8e9-voxel
+volume's zero-bin exceeds both; **`np.histogram`'s bin edges depend on the dtype of `range`** (f32
+scalars → f32-computed linspace; python floats → f64-computed then cast, differing by a few ULP) — pass
+python floats everywhere for cross-path edge consistency; and subsampling the volume (the statistical
+shortcut) was REJECTED here because the metal class can be sparse (Greg) — exact counts were affordable.
+
 Diagnostics: `bytes_in_use` is the WRONG ruler for this class — check `pool_bytes`/`peak_pool_bytes`
 (the retained reservation) at the failure point; the confirming ablation is lowering the mem fraction.
 CONFIRMED on the cluster 2026-07-02: at the norm-OOM point `bytes_in_use` = 0.64 GB while `pool_bytes`

--- a/experiments/sharding/plans/mar_refactor_plan.md
+++ b/experiments/sharding/plans/mar_refactor_plan.md
@@ -39,25 +39,36 @@ The recon steps in the loop (`split_sino_recon` / `recon`) are already sharded �
 
 ## Staged plan
 
-### Phase 1 — Retire the single-device gather (memory; byte-identical)  **[IN PROGRESS]**
-- Drop the `device` param from `_est_plastic_metal_sinos_from_recon` and the
-  `device = ct_model.recon_placement.devices[0]` in `correct_sino_plastic_metal`.  Hand `forward_project`
-  the `plastic_mask` / `mask * recon` directly (host or sharded, as they arrive) and let it shard
-  internally — the host-safe pattern used everywhere else.  Nothing is gathered to one GPU.
-- **Byte-identical (expected):** `forward_project` shards its input the same way whether or not it was
-  first gathered to one device (float32 — same projection, just no gather spike).  If the sharded
-  reduction reorders vs a single-device one, expect ≤ ~1 ULP; document if so.
-- **Gate:** ephemeral before/after on a MAR recon (`num_metal>0`) — corrected sino + recon match
-  (byte-identical or ~ULP); `memory_report` shows no full-volume single-GPU spike on a large run.
+### Phase 1 — Retire the single-device gather (memory; byte-identical)  **[DONE 2026-07-01]**
+- Dropped the `device` param from `_est_plastic_metal_sinos_from_recon` and the
+  `device = ct_model.recon_placement.devices[0]` in `correct_sino_plastic_metal`; `forward_project` now
+  shards `plastic_mask` / `mask*recon` internally (`_shard_recon`, a no-op if already sharded) — no
+  full-volume gather onto one GPU.
+- **Verified byte-identical:** `forward_project(device_put(x, dev0))` == `forward_project(x)` on a
+  4-device model (max_abs_diff 0.0) — the old `device_put` was a pure gather; and an end-to-end MAR smoke
+  (`correct_sino_plastic_metal` on a plastic+metal phantom) produced a finite corrected sino.
 
-### Phase 2 — Correction application through `map_view_batches` with jitted operators (memory + multi-GPU)
-- Run `_correct_plastic_sinogram` / `BH_correction` per view-batch through the shared driver, with the
-  per-batch polynomial evaluation wrapped in `jax.jit` (as `scan_to_sino`'s fused kernel is): fuses the
-  monomial / `H`-column evaluation, reuses buffers, bounds memory, and shards across devices.  Per-pixel
-  (no cross-view coupling) → byte-identical modulo jit-fusion ~ULP.  `theta` (a handful of coefficients)
-  and the exponent lists are closed-over compile constants.  Based on the preprocessing work, jitting the
-  per-batch operator is what keeps the peak bounded (buffer reuse) — Greg's call.
-- **Gate:** before/after ~byte-identical; 1-vs-N device consistent; `memory_report` bounded.
+### Phase 2 — Shard the correction across devices (memory + parallelism)  **[DONE 2026-07-01]**
+Pivoted from `map_view_batches` to **JAX-native view-sharding + SPMD** (Greg): the correction has global
+reductions (`Sp` mean floor, scaling inner products, `HtH`/`Hty`, argmins) that `map_view_batches` (a
+map, not a reduce) can't express, whereas sharded arrays give those reductions as cross-device
+all-reduces *and* run the elementwise steps per-shard in parallel.  Motivation is memory: on a 20+ GB
+sino the un-sharded correction is ~(5+m)×S on one device → OOM; sharded it is ~(5+m)×S/n per device.
+(Speed is a minor bonus — the correction is a few % of the MAR recon.)
+- Projections use `output_sharded=True`; the sinos stay **3-D view-sharded** (no flatten to one device).
+- `_compute_entry_for_OSQP`: `jnp.dot` → `jnp.sum(a*b)` (all-reduces on N-D sharded; padded `h_i`=0 → no
+  mask needed).  `_correct_plastic_sinogram`: `median(Sp)` → **masked mean** (median needs a global sort
+  → would gather; mean all-reduces).  `_estimate_plastic_scaling`: boolean-select → `where`-masked sums.
+  `_find_most_violated_constraints`: masked argmin over real views + flat-index reads.  `_get_row_H`:
+  index the flattened view.  A tiny per-view `view_mask` (1 on real, 0 on the zero-padded views from
+  `prepare_sino_for_devices`) excludes padding from the reductions.  The return `_gather_sinogram`s to a
+  host sino cropped to real views (feeds the recon as before).
+- **Verified (CPU):** `correct_sino_plastic_metal` on a plastic+metal phantom, **n=1 (unpadded) vs n=4
+  (padded/sharded): max_abs 2.2e-4, NRMSE 2.9e-6** — i.e. consistent; the tiny max is the argmin
+  constraint-pixel sensitivity to all-reduce ULP (no padding leak: NRMSE ~ULP, no bias).  Both finite,
+  padding cropped.  Structurally nothing full-length lands on one device (all view-sharded; only the
+  final gather is host).  **Behavior change:** median→mean floor (approved).  **GPU per-device memory +
+  a real MAR before/after to be confirmed on the cluster.**
 
 ### Phase 3 — (DEFERRED — revisit after Phases 1–2) Subsample / speed up the BH model fit
 - The OSQP fit is statistical, so it *could* be estimated from a subsample — the analog of

--- a/experiments/sharding/plans/mar_refactor_plan.md
+++ b/experiments/sharding/plans/mar_refactor_plan.md
@@ -1,10 +1,17 @@
 # MAR (`preprocess/mar.py`) refactor — device management, sharding, memory
 
-**Status:** PLAN (created 2026-06-29; revised 2026-07-01 — phases reordered: the correction-application
-sharding is promoted and done with jitted operators; the BH-fit subsampling is deferred to the end,
-because it needs metal-exposure-diverse sampling, not a uniform subsample).  Scope =
-`mbirjax/preprocess/mar.py` (metal-artifact reduction + beam-hardening correction).  Other half of status
-task #18 (the scan→sino preprocessing half is done).
+**Status:** ✅ **COMPLETE / shipped** (2026-07-03).  Phases 1, 2, 2b, 2c, 2d are all done and committed on
+`greg/shard_profiling`, and validated at full scale on the cluster (the (1800,1365,1880) and 1024³ MAR
+traces that drove the Phase-2d fixes).  Net result: the correction path is view-sharded end-to-end (no
+single-device gather), the recon stays on-device through the BH loop (sharded histogram + Otsu), and the
+memory footguns found in the full-scale trace are fixed.  **Phase 3 (subsample / speed up the BH model fit)
+is DEFERRED and now tracked in `post_shard_plans.md`**, along with the residual open questions below.
+Scope = `mbirjax/preprocess/mar.py` (+ `segmentation.py`, `utilities.py`); the scan→sino preprocessing half
+of status task #18 was already done.
+
+_(History: created 2026-06-29; revised 2026-07-01, phases reordered so the correction-application sharding
+led and the BH-fit subsampling deferred; phases completed through 2026-07-02.  Phase records retained below
+as the implementation log.)_
 
 **Context.** The MAR loop `recon_plastic_metal` alternates `correct_sino_plastic_metal` (beam-hardening
 correction driven by a segmented recon) with `recon`/`split_sino_recon` (already sharded — leave alone).
@@ -159,7 +166,7 @@ Found and fixed while tracing the full-size (1800, 1365, 1880) MAR recon:
   padded==unpadded exact, replicated arrays not double-counted, multi-slab == single-slab, MAR gate
   byte-unchanged.
 
-### Phase 3 — (DEFERRED — revisit after Phases 1–2) Subsample / speed up the BH model fit
+### Phase 3 — (DEFERRED → moved to `post_shard_plans.md`) Subsample / speed up the BH model fit
 - The OSQP fit is statistical, so it *could* be estimated from a subsample — the analog of
   `est_crop_width` / `detect_zinger_pixels`.  **But a uniform view/stride subsample is wrong here:** the
   BH model is identifiable only from sinogram pixels spanning MULTIPLE levels of metal exposure (varying
@@ -188,9 +195,10 @@ Found and fixed while tracing the full-size (1800, 1365, 1880) MAR recon:
 - Phase 3's estimation A/B is a standalone experiment (`theta` full-vs-subsample), not a recon gate until
   the sampling strategy is dialed in.
 
-## Open questions
-- Does `forward_project` shard a single-device-committed input the same as a host/sharded one (Phase 1
-  byte-identicality)?  Confirm on the before/after.
-- `segment_plastic_metal` (in `segmentation.py`): does it return host or device masks? — affects where
-  `mask * recon` lives in Phase 1 (want it sharded/host, not gathered to one device).
-- `gen_huber_weights` / `BH_correction` standalone callers — confirm contracts before touching (Phase 2).
+## Open questions (all resolved during Phases 1–2d)
+- `forward_project` sharding of a single-device-committed input — **resolved:** verified byte-identical to a
+  host/sharded input on a 4-device model (Phase 1); the old `device_put` was a pure gather.
+- `segment_plastic_metal` host-vs-device masks — **resolved:** segmentation now runs on-device (Phase 2b),
+  masks stay sharded, `mask * recon` never gathers to one device.
+- `gen_huber_weights` / `BH_correction` standalone-caller contracts — **resolved** during the Phase-2/2d
+  work (kernels jitted; `gen_huber_weights` body jitted).

--- a/experiments/sharding/plans/mar_refactor_plan.md
+++ b/experiments/sharding/plans/mar_refactor_plan.md
@@ -129,6 +129,36 @@ segmentation is ever fused on-device).
   valley — a tie plateau with zero downstream effect); tests pass.  On real data expect ~bin-scale
   threshold shifts with negligible segmentation change (cluster before/after covers it).
 
+### Phase 2d — Full-scale trace fixes (2026-07-02, from Greg's cluster trace)
+Found and fixed while tracing the full-size (1800, 1365, 1880) MAR recon:
+- **`u_m` flat-index bug** (`_estimate_BH_model_params`): a flat pixel index applied to the now-3-D
+  sinogram grabbed a whole VIEW (TypeError at the constraint concatenate); fixed via
+  `reshape(-1)[i]`; the constraint branches are now exercised by a forced-`tolerance` check (the
+  original gate never entered them).
+- **`split_sino_recon` sharded `init_recon`**: slicing a slice-sharded volume along its sharded axis
+  REPLICATES the half onto every device, and on a padded volume the bottom-half slice picked up
+  padding zeros (correctness).  Fixed by gathering `init_recon` to host at entry (`_gather_recon`,
+  same treatment as sino/weights; preserves the memory-halving design).  Verified byte-identical
+  host-vs-sharded init with the VCD partition RNG seeded.
+- **cuSolver `jnp.linalg.solve` → host `np.linalg.solve`** (tiny QP); **`jnp.linalg.norm` OOM** →
+  per-iteration VCD stats fused into one jitted `_vcd_iteration_stats`; `gen_huber_weights` body
+  jitted.  Root cause class: out-of-pool allocations (cuSolver workspaces, NCCL collective buffers)
+  starved by the retained BFC pool; default mem fraction now `setdefault('0.94')` (was hard-set 0.98).
+  Confirmed on cluster: `pool_bytes` 83.3 GB at `bytes_in_use` 0.64 GB; 0.94 clears the OOM.
+- **Otsu histogram at full scale (47 GiB OOM)**: GSPMD does not partition scatter — `jnp.histogram`
+  AND a global `.at[idx].add` both all-gather image-sized arrays.  Final design (after Greg review;
+  the interim `shard_map` version was dropped per the fbp SPMD-lowering precedent, and the interim
+  volume-subsampling was dropped because the metal class can be sparse): `_sharded_histogram` runs a
+  **per-device local** bucketize+scatter on each device's own shard block (`addressable_shards`,
+  deduped by index), in **≤2^28-element slabs** (int32 exact within a slab; bounds temps), with the
+  tiny partials combined **on the host in int64** — exact counts at any scale, no jax x64, and zero
+  cross-device collectives (min/max also host-combined; slabs all dispatched before any read so
+  devices overlap).  Also fixed on the way: `np.histogram` edges depend on the `range` dtype — all
+  paths now pass python-float endpoints, so the numpy-plain, numpy-masked, and sharded paths produce
+  IDENTICAL thresholds on identical data (verified).  Gate: counts+edges == `np.histogram` (int64),
+  padded==unpadded exact, replicated arrays not double-counted, multi-slab == single-slab, MAR gate
+  byte-unchanged.
+
 ### Phase 3 — (DEFERRED — revisit after Phases 1–2) Subsample / speed up the BH model fit
 - The OSQP fit is statistical, so it *could* be estimated from a subsample — the analog of
   `est_crop_width` / `detect_zinger_pixels`.  **But a uniform view/stride subsample is wrong here:** the

--- a/experiments/sharding/plans/mar_refactor_plan.md
+++ b/experiments/sharding/plans/mar_refactor_plan.md
@@ -106,6 +106,29 @@ Greg's cluster trace: the recon bounced host↔device each BH iteration, and `np
   <sharded>)`); `tests/test_preprocessing.py` + `tests/test_utilities.py` pass (incl. the existing
   cylindrical-mask tests).
 
+### Phase 2c — Otsu threshold search: recursion → vectorized DP  **[DONE 2026-07-02]**
+`_recursive_otsu` + `_binary_threshold_otsu` (per-bin Python loops; ~267 ms at B=1024, k=2; another
+factor of B for k=3) replaced by `_otsu_thresholds_dp`: the within-class-variance objective is
+separable over classes, so the optimum solves the classic 1-D segmentation DP — O(1) interval costs
+from centered moment prefix sums (float64; second moment ~1e15 for 1e9 voxels), one vectorized
+(B+1)² min-reduction per class, argmin backtrack.  **7.8 ms (34×)**, no recursion, host NumPy only
+(jit deliberately NOT used: 1024-bin host problem, float64 safest; a jnp variant is mechanical if
+segmentation is ever fused on-device).
+- **Verification (pre-swap, parallel implementations):** 90 random-histogram trials + a MAR-like
+  phantom hist, refereed by the old scoring function: DP never worse; ALL divergences explained by an
+  off-by-one **in the old code** (`_binary_threshold_otsu` reported inclusive indices, but the scorer
+  and the recursive outer split used half-open boundaries — inner thresholds were optimized under one
+  convention and scored under the other).  DP uses the boundary convention coherently.
+- **Threshold values now `bin_edges[t]`** (was `bin_centers[t]`): under the boundary convention the
+  left edge is the exact cut (values below it fall precisely in the lower classes).  Half-bin-scale
+  value change.
+- Old functions + the scorer **deleted** (Greg); docs/build HTML still shows them until the next docs
+  build (generated artifacts).
+- **Gate:** MAR phantom — thresholds bit-identical host-vs-sharded (n=1, n=3); corrected sino
+  **byte-identical** to the pre-swap output (the threshold move landed inside an empty inter-mode
+  valley — a tie plateau with zero downstream effect); tests pass.  On real data expect ~bin-scale
+  threshold shifts with negligible segmentation change (cluster before/after covers it).
+
 ### Phase 3 — (DEFERRED — revisit after Phases 1–2) Subsample / speed up the BH model fit
 - The OSQP fit is statistical, so it *could* be estimated from a subsample — the analog of
   `est_crop_width` / `detect_zinger_pixels`.  **But a uniform view/stride subsample is wrong here:** the

--- a/experiments/sharding/plans/mar_refactor_plan.md
+++ b/experiments/sharding/plans/mar_refactor_plan.md
@@ -70,6 +70,42 @@ sino the un-sharded correction is ~(5+m)×S on one device → OOM; sharded it is
   final gather is host).  **Behavior change:** median→mean floor (approved).  **GPU per-device memory +
   a real MAR before/after to be confirmed on the cluster.**
 
+### Phase 2b — Keep the recon on the devices through the loop (sharded segmentation)  **[DONE 2026-07-02]**
+Greg's cluster trace: the recon bounced host↔device each BH iteration, and `np.histogram`
+(`segmentation.py`, inside `multi_threshold_otsu`) was the op pinning the recon to the host.
+- **Sharded histogram:** a histogram is sum-decomposable (integer counts; min/max order-insensitive), so
+  `jnp.histogram` on a sharded volume compiles to per-shard partials + all-reduce — verified **0
+  all-gathers** (3 all-reduces for counting; the bin determination = a separate masked min/max pass with
+  its own all-reduces, NOT part of those 3).  `_sharded_histogram` (new, `segmentation.py`) uses masked
+  min/max for the bin range and pushes padded entries to a finite sentinel ABOVE the range (dropped by
+  `histogram` range semantics) → bin edges AND counts **bit-identical** to the unpadded host computation
+  (no post-hoc count correction; Greg's bin-boundary concern resolved by construction).  Memory: temps
+  are shard-bounded (CPU-measured ~2×shard for min/max, ~7×shard worst-case for the histogram; if the
+  cluster fingerprint shows the 7× hurting, swap in a manual bucketize+scatter-add at ~1.3×shard).
+- **`multi_threshold_otsu(valid_mask=None)`:** module-aware — numpy input → host `np.histogram` as
+  before; jax input → `_sharded_histogram` on its own device(s); only the (num_bins,) histogram comes to
+  the host for the threshold search.
+- **`segment_plastic_metal(valid_mask, num_real_slices)`:** class masks are ANDed with `valid_mask` (a
+  threshold interval spanning 0 would otherwise mark the padded zeros and bias
+  `compute_scaling_factor`'s denominator); `apply_cylindrical_mask(num_real_slices=...)` applies the
+  bottom margin at the REAL bottom slices (`[-b:]` would have zeroed the padding instead — latent bug
+  under slice padding, fixed).
+- **`_est_plastic_metal_sinos_from_recon`:** `recon = ct_model._shard_recon(recon)` at entry (no-op if
+  already sharded) + builds the tiny per-slice `valid_mask` from `recon_placement` — segmentation runs
+  on-device and the 1+m projections consume ONE sharded recon instead of re-uploading per mask.
+- **`recon_plastic_metal(..., output_sharded=False)`:** user-facing sharding contract.  Loop internals:
+  `direct_recon(..., output_sharded=True)`; non-cone `recon_function = partial(recon,
+  output_sharded=True)`; **`split_sino_recon` stays host-output by design** (host-split memory halving;
+  device-side stitching noted as a follow-up) — both forms converge at the correction's `_shard_recon`
+  entry and the exit adapter (`_shard_recon`/`_gather_recon` per the kwarg, each a no-op when already in
+  form).
+- **Verified (CPU, n=1 vs n=3 with BOTH view and slice padding):** Otsu thresholds **bit-identical**
+  (host numpy vs sharded+padded); corrected sino consistent (max 9.9e-4 = argmin-ULP scale, NRMSE
+  1.1e-5); `recon_plastic_metal` default returns host ndarray, `output_sharded=True` returns the
+  sharded form, gathered == host **exactly (0.0)** (also implicitly verifies `recon(init_recon=
+  <sharded>)`); `tests/test_preprocessing.py` + `tests/test_utilities.py` pass (incl. the existing
+  cylindrical-mask tests).
+
 ### Phase 3 — (DEFERRED — revisit after Phases 1–2) Subsample / speed up the BH model fit
 - The OSQP fit is statistical, so it *could* be estimated from a subsample — the analog of
   `est_crop_width` / `detect_zinger_pixels`.  **But a uniform view/stride subsample is wrong here:** the

--- a/experiments/sharding/plans/mar_refactor_plan.md
+++ b/experiments/sharding/plans/mar_refactor_plan.md
@@ -166,6 +166,20 @@ Found and fixed while tracing the full-size (1800, 1365, 1880) MAR recon:
   padded==unpadded exact, replicated arrays not double-counted, multi-slab == single-slab, MAR gate
   byte-unchanged.
 
+### Phase 2e — Flat-index >2^31 hazard in the constraint machinery (2026-07-03)
+The "int64 ... truncated to int32" UserWarning in `correct_sino_plastic_metal` flagged a REAL silent
+bug at full scale, introduced by the sharding refactor's flat-index reads: (1) `lax.argmin` computes
+its index labels in int32 (x64 off), so a flat argmin over a >2^31-element sinogram WRAPS — verified:
+a minimum planted at flat 2.3e9 returned −1,994,967,296 (exactly 2^32 off) with NO warning; (2) any
+scalar read on a >2^31-long flat axis requests int64 indices (`int_dtype_for_dim`), truncated with the
+observed warning.  A 4.62e9-pixel sino puts ~53% of positions past 2^31.  Fix: **no flat indices** —
+`_argmin_3d` stages the argmin per axis (per-view argmin over the R*C plane, then argmin over the
+per-view minima; identical row-major tie-breaking; also returns the min value, eliminating the flat
+read) and `_find_most_violated_constraints` now returns **(view, row, col) tuples**; `_get_row_H`,
+`u_m`, and `C_p`/`C_m` use the tuples via basic per-axis indexing (every axis << 2^31 → int32-safe).
+Gates: `_argmin_3d` == flat argmin over 200 trials incl. crafted ties; phantom corrected sino AND
+forced-constraint theta byte-identical; repo audit — these were the only `jnp.argmin/argmax` sites.
+
 ### Phase 3 — (DEFERRED → moved to `post_shard_plans.md`) Subsample / speed up the BH model fit
 - The OSQP fit is statistical, so it *could* be estimated from a subsample — the analog of
   `est_crop_width` / `detect_zinger_pixels`.  **But a uniform view/stride subsample is wrong here:** the

--- a/experiments/sharding/plans/mar_refactor_plan.md
+++ b/experiments/sharding/plans/mar_refactor_plan.md
@@ -1,7 +1,10 @@
 # MAR (`preprocess/mar.py`) refactor — device management, sharding, memory
 
-**Status:** PLAN (created 2026-06-29).  Scope = `mbirjax/preprocess/mar.py` (metal-artifact reduction +
-beam-hardening correction).  The other half of status task #18 (the scan→sino preprocessing half is done).
+**Status:** PLAN (created 2026-06-29; revised 2026-07-01 — phases reordered: the correction-application
+sharding is promoted and done with jitted operators; the BH-fit subsampling is deferred to the end,
+because it needs metal-exposure-diverse sampling, not a uniform subsample).  Scope =
+`mbirjax/preprocess/mar.py` (metal-artifact reduction + beam-hardening correction).  Other half of status
+task #18 (the scan→sino preprocessing half is done).
 
 **Context.** The MAR loop `recon_plastic_metal` alternates `correct_sino_plastic_metal` (beam-hardening
 correction driven by a segmented recon) with `recon`/`split_sino_recon` (already sharded — leave alone).
@@ -11,23 +14,24 @@ The issues are all in the **correction** path.
 
 ## Current issues
 
-1. **Retired single-device pattern (correctness + OOM).** `correct_sino_plastic_metal` does
+1. **Single-device gather (memory; defeats sharding).** `correct_sino_plastic_metal` does
    `device = ct_model.recon_placement.devices[0]`, and `_est_plastic_metal_sinos_from_recon` then does
-   `ct_model.forward_project(jax.device_put(mask * recon, device))` for the plastic mask and each metal
-   mask.  `jax.device_put(mask * recon, device)` forces a **full recon-sized volume onto one GPU** (the
-   single-device-gather footgun we removed elsewhere) and defeats `forward_project`'s internal sharding.
+   `ct_model.forward_project(jax.device_put(mask * recon, device))`.  When `recon` is a sharded array,
+   `device_put(..., device[0])` **gathers the full recon-sized volume onto one GPU** before forward
+   projection — the single-device-gather footgun we removed elsewhere — instead of letting
+   `forward_project` shard internally.
 
-2. **BH model fit runs on the full flattened sinogram (memory + no sharding).**
-   `_est_plastic_metal_sinos_from_recon` returns `forward_project(...).reshape(-1)` — **full-sino-length**
-   vectors (`p`, `m_0`, …) — and the measured sino is flattened too.  `_compute_entry_for_OSQP` builds
-   full-length H columns (`_get_column_H`) and `jnp.dot`s them on one device, **recomputing each column
-   O(num_cols²) times**.  Several full-sino-sized vectors + the dots on one device → single-device memory
-   pressure and slow.  But the fit is **statistical** (a handful of polynomial coefficients via least
-   squares), so it does not need every pixel.
+2. **Correction application on the full sino** (`_correct_plastic_sinogram`, `BH_correction`; batched at
+   64) is per-pixel over the whole (flattened) sinogram → should run per view-batch through the shared
+   `map_view_batches` driver with **jitted** kernels (memory-bounded + multi-GPU + fused), exactly like
+   `scan_to_sino`.
 
-3. **Correction application on the full sino** (`_correct_plastic_sinogram`, `BH_correction` — batched
-   at 64) is per-pixel over the whole sinogram → a candidate for the shared `map_view_batches` driver
-   (memory-bounded + multi-GPU), lower priority than 1–2.
+3. **BH model fit runs on the full flattened sinogram.** `_est_plastic_metal_sinos_from_recon` returns
+   full-sino-length vectors (`p`, `m_i`); `_compute_entry_for_OSQP` builds full-length `H` columns
+   (`_get_column_H`) and dots them on one device, recomputing each column O(num_cols²) times.  The fit is
+   statistical (a few polynomial coefficients), so in principle it needs only a subsample — BUT the
+   subsample must contain pixels spanning DIVERSE metal path length, which are sparse in a mostly-plastic
+   object.  This is the hardest piece and is deferred to Phase 3.
 
 The recon steps in the loop (`split_sino_recon` / `recon`) are already sharded — out of scope.
 
@@ -35,43 +39,58 @@ The recon steps in the loop (`split_sino_recon` / `recon`) are already sharded �
 
 ## Staged plan
 
-### Phase 1 — Retire the single-device pattern (correctness + OOM; byte-identical)
-- Drop the `device` argument from `_est_plastic_metal_sinos_from_recon` and the
-  `device = ...recon_placement.devices[0]` in `correct_sino_plastic_metal`.  Hand `forward_project` a
-  host (or sharded) `mask * recon` and let it shard internally (the host-safe pattern used everywhere
-  else).  `mask`/`recon` arithmetic stays host or on-device per the inputs; nothing is forced onto one
-  GPU.
-- **Byte-identical**: `device_put(x, d)` vs letting `forward_project` shard produces the same values
-  (float32, just placed differently).
-- **Gate:** ephemeral before/after on a MAR recon (Lilly, `num_metal>0`) — sino + recon byte-identical;
-  no full-volume single-GPU spike (a `memory_report` check on a large run).
+### Phase 1 — Retire the single-device gather (memory; byte-identical)  **[IN PROGRESS]**
+- Drop the `device` param from `_est_plastic_metal_sinos_from_recon` and the
+  `device = ct_model.recon_placement.devices[0]` in `correct_sino_plastic_metal`.  Hand `forward_project`
+  the `plastic_mask` / `mask * recon` directly (host or sharded, as they arrive) and let it shard
+  internally — the host-safe pattern used everywhere else.  Nothing is gathered to one GPU.
+- **Byte-identical (expected):** `forward_project` shards its input the same way whether or not it was
+  first gathered to one device (float32 — same projection, just no gather spike).  If the sharded
+  reduction reorders vs a single-device one, expect ≤ ~1 ULP; document if so.
+- **Gate:** ephemeral before/after on a MAR recon (`num_metal>0`) — corrected sino + recon match
+  (byte-identical or ~ULP); `memory_report` shows no full-volume single-GPU spike on a large run.
 
-### Phase 2 — Subsample the BH model fit (the big memory/speed win)
-- The OSQP fit is statistical, so estimate `HtH`/`Hty` (and the constraint search) from a sinogram
-  **subsample** — the exact analog of `est_crop_width` / `detect_zinger_pixels`.  Subsample on a flat
-  index stride (or by view) so `p`/`m_i`/`measured` and the H columns are small; apply the resulting
-  `theta` correction to the **full** sino (the application is per-pixel and must stay full).
-- Bonus: compute each H column **once** (cache), instead of O(num_cols²) recomputation.
-- **NOT byte-identical** (a subsampled least-squares fit differs slightly).  **Gate:** the corrected
-  recon matches the full-fit recon within a documented tolerance on the Lilly MAR run (the fit is a
-  smooth low-order model, so a representative subsample should be very close); sweep the subsample size
-  to pick the knee.
+### Phase 2 — Correction application through `map_view_batches` with jitted operators (memory + multi-GPU)
+- Run `_correct_plastic_sinogram` / `BH_correction` per view-batch through the shared driver, with the
+  per-batch polynomial evaluation wrapped in `jax.jit` (as `scan_to_sino`'s fused kernel is): fuses the
+  monomial / `H`-column evaluation, reuses buffers, bounds memory, and shards across devices.  Per-pixel
+  (no cross-view coupling) → byte-identical modulo jit-fusion ~ULP.  `theta` (a handful of coefficients)
+  and the exponent lists are closed-over compile constants.  Based on the preprocessing work, jitting the
+  per-batch operator is what keeps the peak bounded (buffer reuse) — Greg's call.
+- **Gate:** before/after ~byte-identical; 1-vs-N device consistent; `memory_report` bounded.
 
-### Phase 3 — (optional) Drive the correction application through `map_view_batches`
-- Run `_correct_plastic_sinogram` / `BH_correction` per view-batch through the shared driver for
-  memory-bounded + multi-GPU application on the full sino.  Per-pixel → byte-identical (eager kernels).
-- **Gate:** before/after byte-identical; 1-vs-N device byte-identical.
+### Phase 3 — (DEFERRED — revisit after Phases 1–2) Subsample / speed up the BH model fit
+- The OSQP fit is statistical, so it *could* be estimated from a subsample — the analog of
+  `est_crop_width` / `detect_zinger_pixels`.  **But a uniform view/stride subsample is wrong here:** the
+  BH model is identifiable only from sinogram pixels spanning MULTIPLE levels of metal exposure (varying
+  metal path length), and those are **sparse** in a mostly-plastic object with small metal parts.  A
+  uniform subsample would be dominated by plastic-only / zero-metal pixels and under-determine the metal
+  terms.
+- So this needs **metal-thresholded targeted subsampling** — select pixels by their estimated metal path
+  length (from `metal_sino_est`) to cover the exposure range (e.g. stratify by metal magnitude / keep
+  pixels above a metal threshold plus a plastic sample).  That is a more involved refactor than the other
+  subsamplers, hence deferred.
+- Independent, cheaper win to fold in here: cache each `H` column once (`_get_column_H`) instead of the
+  O(num_cols²) recomputation in `_compute_entry_for_OSQP`.
+- **A/B test the estimation IN ISOLATION first:** as a standalone experiment, compare the fitted `theta`
+  (and the resulting corrected sino) from the full fit vs the targeted-subsample fit — *before* wiring
+  the subsampling into the recon loop.  Sweep the subsample size/strategy to pick the knee.  NOT
+  byte-identical by design; gate on the corrected recon within a documented tolerance.
 
 ---
 
 ## Validation strategy
-- **Ephemeral real-data before/after** on a Lilly MAR recon (`recon_plastic_metal`, `num_metal>0`),
-  same platform — capture the current corrected sino + recon, then verify after each phase (Phase 1
-  byte-identical; Phase 2 tolerance; Phase 3 byte-identical).  Discard after, like the other baselines.
-- Watch peak memory on a large run (`memory_report`) — Phase 1 removes the full-volume single-GPU spike;
-  Phase 2 removes the full-sino fit vectors.
+- **Ephemeral real-data before/after** on a MAR recon (`recon_plastic_metal`, `num_metal>0`), same
+  platform — capture the current corrected sino + recon, verify after each phase (Phase 1 ~byte-identical;
+  Phase 2 ~byte-identical; Phase 3 tolerance).  Discard after, like the other baselines.
+- Watch peak memory (`memory_report`) on a large run — Phase 1 removes the full-volume single-GPU gather;
+  Phase 2 bounds the application memory.
+- Phase 3's estimation A/B is a standalone experiment (`theta` full-vs-subsample), not a recon gate until
+  the sampling strategy is dialed in.
 
 ## Open questions
-- `gen_huber_weights` / `BH_correction` standalone callers — confirm their contracts before touching.
-- Whether `segment_plastic_metal` (in `segmentation.py`) returns host or device masks — affects where
-  `mask * recon` lives in Phase 1.
+- Does `forward_project` shard a single-device-committed input the same as a host/sharded one (Phase 1
+  byte-identicality)?  Confirm on the before/after.
+- `segment_plastic_metal` (in `segmentation.py`): does it return host or device masks? — affects where
+  `mask * recon` lives in Phase 1 (want it sharded/host, not gathered to one device).
+- `gen_huber_weights` / `BH_correction` standalone callers — confirm contracts before touching (Phase 2).

--- a/experiments/sharding/plans/post_shard_plans.md
+++ b/experiments/sharding/plans/post_shard_plans.md
@@ -8,6 +8,17 @@ Roughly ordered by likely value; none is blocking.
 
 ---
 
+## 0. Done during PR prep (2026-07-03)
+
+- **MAR test coverage** (`tests/sharding/test_mar.py` — was zero): `_argmin_3d` vs flat argmin incl.
+  tie cases; corrected-sino 1-vs-3-device consistency with view AND slice padding (tol 1e-3 — the BH
+  constraint SELECTION is discretely sensitive to reduce-order noise); the forced-constraint path
+  (`tolerance=1e10` — where the flat-index bugs lived); the empty-plastic `ValueError` guard; the
+  `recon_plastic_metal` `output_sharded` contract (seeded partitions).
+- **`vcls.py` eager norms** (the last `jnp.linalg` survey stragglers): per-view normalize +
+  projection folded into jitted helpers (`_normalize_by_norm` / `_normalize_and_project`); also
+  collapsed a historical double-eps on the `recon_i` path (~1e-12).
+
 ## 1. Size-adaptive memory knobs (biggest near-term win)
 
 The recon's peak on large multi-GPU problems is now set by a couple of hardwired batch/granularity
@@ -49,9 +60,12 @@ the 'flash' associated with objects partially outside the FoV.
 
 ## 4. MAR Phase 3 — subsample / speed up the BH model fit
 
-From `mar_refactor_plan.md` Phase 3.  The OSQP beam-hardening fit is statistical, so it *could* run on a
-subsample — but a **uniform** view/stride subsample is wrong: the model is only identifiable from pixels
-spanning diverse **metal path length**, which are sparse in a mostly-plastic object.
+From `mar_refactor_plan.md` Phase 3.  **This is now a SPEED-only item**: the fit's memory was solved by
+Phase 2 (the `HtH`/`Hty` inner products and constraint argmins run on the view-sharded sinograms), so
+the fit cannot OOM — subsampling would only reduce its time.  The OSQP beam-hardening fit is
+statistical, so it *could* run on a subsample — but a **uniform** view/stride subsample is wrong: the
+model is only identifiable from pixels spanning diverse **metal path length**, which are sparse in a
+mostly-plastic object.
 - Needs **metal-thresholded targeted subsampling** (stratify by estimated metal magnitude; keep high-metal
   pixels + a plastic sample).
 - Cheap independent win to fold in: **cache each `H` column once** instead of the O(num_cols²) recompute.
@@ -99,3 +113,6 @@ spanning diverse **metal path length**, which are sparse in a mostly-plastic obj
   wrapped in `<a>`; fix per case (qualify / correct target / document the target / downgrade to literal).
 - **Suite tidiness** (§6): seed the remaining unseeded-`np.random` tests; a pre-merge
   `import mbirjax`-before-`jax` sweep; public `shard_*` / `gather_*` wrappers.
+- **>2^31 audit sweep**: grep for remaining flat-index / count-unsafe ops on full-size arrays
+  (`argsort`, `searchsorted`, large `cumsum` indices, `nonzero`), applying `lessons.md` §4 (the
+  `argmin`/`np.prod`/histogram-count instances are fixed; this closes the class).

--- a/experiments/sharding/plans/post_shard_plans.md
+++ b/experiments/sharding/plans/post_shard_plans.md
@@ -1,0 +1,101 @@
+# Post-sharding forward plan
+
+**Created 2026-07-03.**  Open items carried forward now that the core sharding (ParallelBeam + all
+geometries), the MAR/preprocessing sharding, and the large-problem memory work have shipped on
+`greg/shard_profiling`.  This is the running "what's left" list; detail lives in the source docs cited
+per item (`mar_refactor_plan.md`, `sharding_implementation_plan_v3.md` §4/§5/§6, `sinogram_sharding.md`).
+Roughly ordered by likely value; none is blocking.
+
+---
+
+## 1. Size-adaptive memory knobs (biggest near-term win)
+
+The recon's peak on large multi-GPU problems is now set by a couple of hardwired batch/granularity
+constants that were tuned for small volumes.  Both should become **size-adaptive but hardware-independent**
+(a function of the *problem*, identical on any device count — else results would drift with hardware and
+break the cross-device correctness gating).
+
+- **Adaptive `view_batch_size_for_vmap`.**  Currently hardwired to **128** (was 512; the forward-projection
+  transient scales with it and OOM'd cone 1024³).  Make it scale down with recon size (large recons want it
+  smaller; small recons are unaffected), and pick a **divisor of the per-view-shard view count** so there is
+  no ragged tail batch.  _(TODO note is in `tomography_model.py`; supersedes the hardwired 128.)_
+- **Size-only adaptive `partition_sequence` / starting granularity** (`sharding_implementation_plan_v3.md`
+  §5 P1-design).  The granularity-1 first VCD iteration updates the whole recon in one subset → the biggest
+  subset-domain arrays.  Deriving the coarsest starting granularity from voxel count (skip granularity 1 for
+  large problems) shrinks those.  **Size-only, never memory/hardware-adaptive** (reproducibility), and
+  **gated on convergence-quality data** from an 8-GPU run (does skipping granularity 1 hurt the final
+  image?).  Until verified: keep the `[0,2,4,6,7]` default + the documented "use a finer sequence for large
+  multi-device problems" guidance.
+- These two are the same class of policy (problem-size → memory knob); worth unifying under one place.
+
+## 2. Sinogram weight edge tapering to speed convergence and reduce flash
+
+ConeBeamModel → split_sino_recon() uses a per-detector-row sine filter on sinogram weights to reduce ringing 
+artifacts associated with windowing with a rect in detector rows when splitting the full recon into 
+two pieces.  Also, observation indicates that objects that extend outside the field of view
+lead to slower convergence.  
+- Hence we should investigate whether a geometry-adaptive (and possibly data-adaptive) 
+filtering of sinogram edges (both in rows and channels) may speed convergence and/or reduce
+the 'flash' associated with objects partially outside the FoV.
+
+## 3. Projector / batching profiling and cleanup
+
+- **Profile the existing projector performance**: Use jax/perfetto/tensorboard/nvidia tools to identify
+  memory and computational bottlenecks and make a plan to improve performance.
+- **Simplify the sparse-projector batching machinery** (§6): collapse the scan/map/vmap nest, remove the
+  `lax.map` jax#27591 fragility (`apply_row_filter` is the template).  High blast-radius — do on its own with
+  the projector suite as the gate.
+- **Minor opens:** `configure_devices`/`use_gpu` unification; forward pixel-batch default.
+
+## 4. MAR Phase 3 — subsample / speed up the BH model fit
+
+From `mar_refactor_plan.md` Phase 3.  The OSQP beam-hardening fit is statistical, so it *could* run on a
+subsample — but a **uniform** view/stride subsample is wrong: the model is only identifiable from pixels
+spanning diverse **metal path length**, which are sparse in a mostly-plastic object.
+- Needs **metal-thresholded targeted subsampling** (stratify by estimated metal magnitude; keep high-metal
+  pixels + a plastic sample).
+- Cheap independent win to fold in: **cache each `H` column once** instead of the O(num_cols²) recompute.
+- **A/B the estimation in isolation first** (fitted `theta` + corrected recon, full vs subsample; sweep the
+  subsample size/strategy for the knee) before wiring into the loop.  Not byte-identical by design; gate on
+  the corrected recon within a documented tolerance.
+
+## 5. Device-count / communication policy
+
+- **Choose-N-vs-communication policy** (`sharding_implementation_plan_v3.md` §5): when does adding a device
+  pay vs. its comms cost?  Includes the **CPU-cluster auto-sharding policy** (real-cluster perf + a
+  virtual-vs-real-CPU topology rule).
+- **Auto device-count basis — recon-slices vs sino-views** (§6, OPEN).  `_auto_device_count` trims on the
+  recon-**slice** axis, but projection compute lives on the **view-owners**, so the slice axis is the wrong
+  proxy for "does this device do real work."  Revisit the basis (likely views, or both) as part of choose-N.
+
+## 6. Geometry fidelity
+
+- **Multiaxis vertical-fan `1/cos(elevation)` path-length factor — OPEN** (§6).  Vertical fan uses
+  `scaling = 1.0`; for elevation ≠ 0 / non-unit slice aspect the absolute magnitude is self-consistent
+  (adjoint holds) but not anchored to a reference.  The right factor must be **derived from the multiaxis
+  path length** (the detector is ⟂ to the tilted ray — no cone-style incidence obliquity), not copied from
+  cone.  Take up as a separate change with a **physical-fidelity gate** (forward-project a known object vs an
+  analytic line integral).  Acceptable as-is for an MBIR initializer.
+
+## 7. Performance (deferred — only if it ever matters)
+
+- **B4.5 — band-kernel GPU cost** (§4).  The band (reduce-scatter) back kernel is ~2.25× slower than the
+  rolled-pixel kernel on GPU, and the two are platform-opposite (CPU likes band, GPU likes pixel).  Multi-
+  device back doesn't pay in *time* until ≥3 GPUs; VCD stays monotonic because the forward masks it.
+  Deferred (sharding is the capacity tool, not a back-time lever).  **Alternative axis:** shard the sinogram
+  by **detector row** instead of by view, aligning the sino's sharded axis with the recon's slice sharding →
+  back projection becomes mostly-local (a footprint halo) instead of a view-reduce.  Parked; full analysis in
+  `.claude/sinogram_sharding.md`.
+- **Prox-map (PnP) prior under sharding** — revisit only if a plug-and-play-at-scale need appears (§5).
+
+## 8. Robustness / cleanup
+
+- **Multi-GPU OOM that *hangs* → catchable error** (§5, STILL OPEN).  A GPU stuck in the BFC retry loop never
+  reaches the NCCL rendezvous → "Acquire clique" timeout, so no exception is raised and the OOM hint never
+  prints (the exact 2048³/8 cone case).  Converting the hang into a clean error is a bigger allocator/
+  collective-timeout change; left as a separate follow-on.
+- **Deferred docs-cleanup pass** (§5): the remaining unresolved Sphinx py-xrefs that silently render as
+  plain `<code>` (no warning).  Detect by building the HTML and grepping for `<code class="xref py …">` not
+  wrapped in `<a>`; fix per case (qualify / correct target / document the target / downgrade to literal).
+- **Suite tidiness** (§6): seed the remaining unseeded-`np.random` tests; a pre-merge
+  `import mbirjax`-before-`jax` sweep; public `shard_*` / `gather_*` wrappers.

--- a/experiments/sharding/plans/pr_description_draft.md
+++ b/experiments/sharding/plans/pr_description_draft.md
@@ -40,6 +40,14 @@ order, set the variables in the environment before launching Python, e.g. `expor
   reconstruction to HDF5 no longer fails.**
 - **Clearer out-of-memory guidance** is printed when a reconstruction exceeds GPU memory, including how to
   reduce peak memory.
+- **The GPU memory reservation is now 94% and user-overridable.**  mbirjax previously hard-set
+  `XLA_PYTHON_CLIENT_MEM_FRACTION=0.98`, which left almost no room for allocations that live outside
+  XLA's pool (GPU library workspaces such as cuSolver, and the NCCL buffers used by multi-GPU
+  reductions) -- these could fail with out-of-memory errors even when the pool itself was nearly idle.
+  The default is now `0.94`, set with `setdefault` so setting the environment variable before importing
+  mbirjax overrides it.  Per-iteration reconstruction statistics are also computed in a single fused
+  pass (rather than several separate full-array operations), which both removes sinogram-sized
+  temporaries and reduces the number of separate multi-GPU collective allocations.
 
 ## Two-stage preprocessing / reconstruction
 

--- a/mbirjax/_sharding/placement.py
+++ b/mbirjax/_sharding/placement.py
@@ -92,6 +92,34 @@ class Placement:
         problem's real axis (real_size does not divide the device count)."""
         return self.padded_size is not None and self.padded_size > self.real_size
 
+    def real_mask(self, ndim):
+        """Broadcastable indicator of the REAL entries of a device-form array under this placement.
+
+        Returns None when nothing is padded (the common case -- callers use None as "no masking
+        needed").  Otherwise returns a host NumPy boolean array of rank ``ndim`` that is
+        ``padded_size`` long on this placement's shard axis and 1 elsewhere, True on the real entries
+        and False on the zero-filled padding.  Broadcasting it against the device-form array lets
+        statistical reductions (means, argmins, histograms, masked sums) exclude the padded entries;
+        as a tiny HOST constant it auto-promotes to whatever device(s) the computation runs on.
+
+        This is the reduction-side complement of ``TomographyModel._mask_padded_views``, which ZEROES
+        the padding inside per-owner local blocks during projector assembly -- an apply operation on
+        the per-device arrays, deliberately not expressed as a broadcast multiply.  The two serve
+        different mechanisms and are intentionally separate.
+
+        Args:
+            ndim (int): rank of the device-form array the mask will broadcast against.
+
+        Returns:
+            numpy.ndarray or None: boolean mask of shape (1, ..., padded_size, ..., 1), or None when
+            the placement is unpadded.
+        """
+        if not self.is_padded:
+            return None
+        mask_shape = [1] * ndim
+        mask_shape[self.axis % ndim] = self.padded_size
+        return (np.arange(self.padded_size) < self.real_size).reshape(mask_shape)
+
     def padded_shard_ranges(self):
         """``shard_ranges`` over the device-form (padded) axis length, plus each
         shard's count of REAL (problem-owned) entries.

--- a/mbirjax/cone_beam.py
+++ b/mbirjax/cone_beam.py
@@ -1188,6 +1188,15 @@ class ConeBeamModel(TomographyModel):
         sino = np.asarray(sino)
         if weights is not None:
             weights = np.asarray(weights)
+        if init_recon is not None and isinstance(init_recon, jax.Array):
+            # Same host-side treatment as sino/weights, for two reasons.  (1) Slicing a slice-sharded
+            # volume along its sharded axis REPLICATES the half onto every device (a full half-recon
+            # copy per device) just before the half-recon builds its working set; host slicing keeps
+            # only one half's arrays device-resident at a time -- the point of this function.
+            # (2) _gather_recon crops any zero-padded slices of a device-form volume; without the crop,
+            # the bottom-half slice init_recon[:, :, -num_slices:] would pick up padding zeros instead
+            # of the real bottom slices.
+            init_recon = self._gather_recon(init_recon)
 
         # Get parameters for later use
         num_views, full_num_rows, num_cols = sino.shape

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -3,6 +3,7 @@ import jax.numpy as jnp
 import numpy as np
 import mbirjax as mj
 import mbirjax.preprocess as mjp
+from . import pipeline
 import random
 import warnings
 from scipy.sparse import csc_matrix
@@ -68,7 +69,7 @@ def gen_huber_weights(weights, sino_error, T=1.0, delta=1.0, epsilon=1e-6):
     return huber_weights
 
 
-def BH_correction(sino, alpha, batch_size=64):
+def BH_correction(sino, alpha, batch_size=64, devices=None):
     """
     Apply a polynomial beam hardening correction to a sinogram.
 
@@ -99,28 +100,19 @@ def BH_correction(sino, alpha, batch_size=64):
         >>> alpha = [1.0, 0.2, 0.1]  # Correction: sino + 0.2 * sino^2 + 0.1 * sino^3
         >>> corrected_sino = mjp.BH_correction(sino, alpha)
     """
-    # Ensure inputs are JAX arrays
-    sino = jnp.asarray(sino)
     alpha = jnp.asarray(alpha)
 
-    views, rows, cols = sino.shape
-    corrected = []
-
-    for i in range(0, views, batch_size):
-        sino_batch = sino[i:i+batch_size]
-
-        # Initialize corrected batch to the linear term (sino_batch)
-        corrected_batch = jnp.zeros_like(sino_batch)
-
-        # Apply polynomial terms
+    # Per-view-batch polynomial evaluation, driven through the shared pipeline driver: jitted so XLA
+    # fuses the powers + weighted sum (buffer reuse, bounded memory), and memory-bounded / optionally
+    # multi-device via map_view_batches.  The correction is per-pixel, so batching is exact.
+    @jax.jit
+    def kernel(sino_batch):
+        corrected = jnp.zeros_like(sino_batch)
         for k in range(len(alpha)):
-            corrected_batch += alpha[k] * jnp.power(sino_batch, k + 1)
+            corrected = corrected + alpha[k] * jnp.power(sino_batch, k + 1)
+        return corrected
 
-        corrected.append(corrected_batch)
-
-    corrected_sino = jnp.concatenate(corrected, axis=0)
-
-    return corrected_sino
+    return pipeline.map_view_batches(sino, kernel, batch_size, devices=devices)
 
 
 def _generate_metal_exponent_list(num_metal, max_order):
@@ -176,17 +168,18 @@ def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model):
     # metal_scales: List of scaling factors for each metal region.
     plastic_mask, metal_masks, plastic_scale, metal_scales = mjp.segment_plastic_metal(recon, num_metal=num_metal)
 
-    # --- Forward project, scale and vectorize plastic ---
+    # --- Forward project and scale plastic ---
     # forward_project shards its input internally (_shard_recon), so hand it the mask/masked-recon
-    # directly -- do NOT jax.device_put the recon-sized array onto one device first (that would gather
-    # the whole volume onto a single GPU, spiking memory and defeating the projector's sharding).
-    # plastic_mask / mask*recon inherit recon's layout (sharded stays sharded; host stays host).
-    plastic_sino_est = plastic_scale * ct_model.forward_project(plastic_mask).reshape(-1)
+    # directly -- do NOT jax.device_put the recon-sized array onto one device first.  Keep the OUTPUT
+    # view-sharded (output_sharded=True) and do NOT flatten: the whole correction below runs on these
+    # sharded 3-D sinograms so no full-length sino vector ever lands on a single device.  (plastic_mask /
+    # mask*recon inherit recon's layout; the sino outputs are view-sharded per sino_placement.)
+    plastic_sino_est = plastic_scale * ct_model.forward_project(plastic_mask, output_sharded=True)
 
     # --- Forward project the masked out metal regions ---
     metal_sino_est = []
     for mask, scale in zip(metal_masks, metal_scales):
-        m = ct_model.forward_project(mask * recon).reshape(-1)
+        m = ct_model.forward_project(mask * recon, output_sharded=True)
         metal_sino_est.append(m)
 
     return plastic_sino_est, metal_sino_est
@@ -232,8 +225,11 @@ def _get_row_H(row_index, plastic_sino_est, metal_sino_est, H_exponent_list):
     Returns:
         jnp.ndarray: The computed row of H.
     """
-    pi = plastic_sino_est[row_index]
-    mi = [m[row_index] for m in metal_sino_est]
+    # row_index is a FLAT pixel index (from argmin over the flattened sinogram); the sinos are now 3-D
+    # (view-sharded), so index the flattened view (reshape(-1) preserves the sharding; this is a
+    # single-element gather).
+    pi = plastic_sino_est.reshape(-1)[row_index]
+    mi = [m.reshape(-1)[row_index] for m in metal_sino_est]
     row_vals = []
     for exps in H_exponent_list:
         val = (pi ** exps[0])
@@ -243,7 +239,7 @@ def _get_row_H(row_index, plastic_sino_est, metal_sino_est, H_exponent_list):
     return jnp.asarray(row_vals)
 
 
-def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms):
+def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms, view_mask=None):
     """
     Compute the most violated constraints for the beam hardening model.
 
@@ -252,13 +248,15 @@ def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_
         2. Residual positivity:       y[i] − H_m[i,:] θ_m ≥ 0
 
     This function evaluates the indices and values of the entries that most violate
-    the constraints.
+    the constraints.  When the sinograms are device-form (view-sharded, possibly zero-padded on the view
+    axis), ``view_mask`` (1 on real views, 0 on padded, broadcasting over the sinogram) excludes the
+    padded views from the argmin so a padded entry is never selected as a constraint.
 
     Returns:
-        i_min_Sp (int): Index of smallest Sp entry.
-        v_min_Sp (float): Value of Sp[i_min_Sp].
-        i_min_residual (int): Index of smallest (y − Sm) entry.
-        v_min_residual (float): Value of (y − Sm)[i_min_residual].
+        i_min_Sp (int): FLAT index of smallest Sp entry (into the flattened sinogram).
+        v_min_Sp (float): Value of Sp at that entry.
+        i_min_residual (int): FLAT index of smallest (y − Sm) entry.
+        v_min_residual (float): Value of (y − Sm) at that entry.
     """
     num_cols = len(H_exponent_list)
     Sp = jnp.zeros_like(measured_sino)
@@ -272,12 +270,16 @@ def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_
     for j in range(1 + num_cross_terms, num_cols):
         y_minus_Sm = y_minus_Sm - theta[j] * _get_column_H(j, plastic_sino_est, metal_sino_est, H_exponent_list)
 
-    # Lower-bound violator: minimize Sp and y-Sm
-    i_min_Sp = int(jnp.argmin(Sp))
-    i_min_residual = int(jnp.argmin(y_minus_Sm))
+    # Lower-bound violator: minimize Sp and y-Sm over the REAL views (padded views set to +inf so they
+    # can't win the argmin).  argmin over the N-D sinogram returns a FLAT index; read the values back via
+    # the flattened view (reshape(-1) preserves the sharding).
+    Sp_masked = Sp if view_mask is None else jnp.where(view_mask > 0, Sp, jnp.inf)
+    ymSm_masked = y_minus_Sm if view_mask is None else jnp.where(view_mask > 0, y_minus_Sm, jnp.inf)
+    i_min_Sp = int(jnp.argmin(Sp_masked))
+    i_min_residual = int(jnp.argmin(ymSm_masked))
 
-    v_min_Sp = Sp[i_min_Sp]
-    v_min_residual = y_minus_Sm[i_min_residual]
+    v_min_Sp = Sp.reshape(-1)[i_min_Sp]
+    v_min_residual = y_minus_Sm.reshape(-1)[i_min_residual]
 
     return i_min_Sp, v_min_Sp, i_min_residual, v_min_residual
 
@@ -329,13 +331,16 @@ def _compute_entry_for_OSQP(plastic_sino_est, metal_sino_est, measured_sino, H_e
     HtH = jnp.zeros((num_cols, num_cols))
     Hty = jnp.zeros(num_cols)
 
-    # Compute the upper triangle of HtH and mirror it.
+    # Compute the upper triangle of HtH and mirror it.  Use jnp.sum(a*b) rather than jnp.dot so the
+    # inner products work on the N-D view-sharded sinograms (a cross-device all-reduce).  Padded views
+    # contribute 0 (their h_i are built from plastic/metal, which are 0 on padded views), so no mask is
+    # needed here.
     for i in range(num_cols):
         h_i = _get_column_H(i, plastic_sino_est, metal_sino_est, H_exponent_list)
-        Hty = Hty.at[i].set(jnp.dot(h_i, measured_sino))
+        Hty = Hty.at[i].set(jnp.sum(h_i * measured_sino))
         for j in range(i, num_cols):
             h_j = _get_column_H(j, plastic_sino_est, metal_sino_est, H_exponent_list)
-            dot_ij = jnp.dot(h_i, h_j)
+            dot_ij = jnp.sum(h_i * h_j)
             HtH = HtH.at[i, j].set(dot_ij)
             if i != j:
                 HtH = HtH.at[j, i].set(dot_ij)
@@ -359,7 +364,7 @@ def _compute_entry_for_OSQP(plastic_sino_est, metal_sino_est, measured_sino, H_e
 
     return P, q
 
-def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H_exponent_list, num_cross_terms, alpha, beta, num_constraint_update_iter=10, tolerance=-1e-5):
+def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H_exponent_list, num_cross_terms, alpha, beta, num_constraint_update_iter=10, tolerance=-1e-5, view_mask=None):
     """
     Estimate polynomial beam hardening model parameters with iterative constraints search.
 
@@ -412,7 +417,7 @@ def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H
 
     for iter in range(num_constraint_update_iter):
         # Find the indices and values of the points that most violate each constraint
-        i_min_Sp, v_min_Sp, i_min_residual, v_min_residual = _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms)
+        i_min_Sp, v_min_Sp, i_min_residual, v_min_residual = _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms, view_mask=view_mask)
 
         # (1) Hp θp ≥ 0  ->  (-Hp) θ ≤ 0
         if v_min_Sp < tolerance and (i_min_Sp not in C_p):
@@ -441,7 +446,7 @@ def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H
     return theta
 
 
-def _correct_plastic_sinogram(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms, num_metal_terms, p_normalization, gamma):
+def _correct_plastic_sinogram(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms, num_metal_terms, p_normalization, gamma, view_mask=None, num_real_pixels=None):
     """
     Perform beam hardening correction on the plastic sinogram.
 
@@ -456,9 +461,10 @@ def _correct_plastic_sinogram(measured_sino, plastic_sino_est, metal_sino_est, t
 
     The H matrix looks like: [p, p*m, p*m^2, m, m^2, m^3]
     The correction is applied as:
-        corrected_plastic = p_normalization * max(y - H_metal·θ_m, 0) / (max(H_plastic·θ_p, γ * median(H_plastic·θ_p))
+        corrected_plastic = p_normalization * max(y - H_metal·θ_m, 0) / (max(H_plastic·θ_p, γ * mean(H_plastic·θ_p))
     The stabilization term involving γ prevents division by near-zero or negative values, reducing streaks
-    and numerical instability.
+    and numerical instability.  (``view_mask`` / ``num_real_pixels`` restrict the mean to the real views
+    when the sinogram is device-form and zero-padded.)
 
     Args:
         measured_sino (jnp.ndarray): Measured sinogram.
@@ -489,14 +495,21 @@ def _correct_plastic_sinogram(measured_sino, plastic_sino_est, metal_sino_est, t
     # Enforce non-negativity on the residual sinogram (plastic + cross terms)
     y_minus_Sm = jnp.maximum(y_minus_Sm, 0)
 
-    # Compute median of plastic coefficients (used to define a stabilization floor)
-    median_plastic_coef = jnp.median(Sp)
-    Sp_floor = gamma * median_plastic_coef
+    # Central plastic coefficient, used to define a stabilization floor.  We use the MEAN rather than the
+    # median so it is a cross-device all-reduce (median needs a global sort, which would gather the
+    # sharded sinogram back to one device); over the sinogram support the two are close, and this only
+    # sets a floor.  When the sinogram is view-sharded and zero-padded, exclude the padded views via
+    # view_mask so they don't drag the mean toward 0.
+    if view_mask is None:
+        mean_plastic_coef = jnp.mean(Sp)
+    else:
+        mean_plastic_coef = jnp.sum(Sp * view_mask) / num_real_pixels
+    Sp_floor = gamma * mean_plastic_coef
 
-    # A negative median would be non-physical and may indicate instability in the algorithm
+    # A negative mean would be non-physical and may indicate instability in the algorithm
     # In that case, issue a runtime warning to flag the potential problem
-    if float(median_plastic_coef) <= 0:
-        warnings.warn("Median of Sp is negative", RuntimeWarning)
+    if float(mean_plastic_coef) <= 0:
+        warnings.warn("Mean of Sp is negative", RuntimeWarning)
 
     # Clamp Sp at Sp_floor to prevent division by very small or negative values
     clamped_plastic_coef = jnp.maximum(Sp, Sp_floor)
@@ -511,10 +524,15 @@ def _estimate_plastic_scaling(plastic_sino_est, metal_sino_est, measured_sino, p
     for metal in metal_sino_est:
         metal_absent = metal_absent & (metal == 0)
 
-    # Find the metal-absent indices
+    # Plastic-only locations.  Instead of boolean-index selection (measured[condition]) -- which has a
+    # data-dependent shape and would gather the view-sharded sinogram to one device -- zero out the other
+    # locations and let compute_scaling_factor's inner products (sum(a*b)/sum(b*b)) all-reduce over the
+    # shards.  This also drops padded views (plastic==0 there, so condition is False), so no separate
+    # real-view mask is needed here.
     condition = (plastic_sino_est != 0) & metal_absent
 
-    plastic_sino_scale = mjp.compute_scaling_factor(measured_sino[condition], plastic_sino_corrected[condition])
+    plastic_sino_scale = mjp.compute_scaling_factor(jnp.where(condition, measured_sino, 0.0),
+                                                    jnp.where(condition, plastic_sino_corrected, 0.0))
     return plastic_sino_scale
 
 def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, order=3, alpha=1, beta=0.002, gamma=0.1, num_constraint_update_iter=10):
@@ -554,34 +572,47 @@ def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, orde
             [(1, *t) for t in cross_exponent_list] +
             [(0, *t) for t in metal_exponent_list])
 
-    sino_shape = measured_sino.shape
-    measured_sino = measured_sino.reshape(-1)
+    # Shard the measured sinogram to the model's devices (view-sharded, zero-padded on the view axis to
+    # divide evenly).  Keep it as a 3-D view-sharded array -- do NOT flatten to one device -- so the whole
+    # correction runs on view-sharded sinograms and no full-length sino vector lands on a single device
+    # (critical for large, e.g. 20+ GB, sinograms).  The estimates below stay view-sharded too
+    # (output_sharded=True), so every step is a per-shard elementwise op or a cross-device reduction.
+    measured_sino = ct_model.prepare_sino_for_devices(measured_sino)
 
-    # Get normalized sinogram p and [m_0, m_1, ...].  forward_project inside handles device placement
-    # (sharding internally); nothing is gathered onto a single device here.
+    # Real-view mask (1 on real views, 0 on padded) broadcasting over the shard axis, plus the real pixel
+    # count -- used to exclude padded views from the statistical reductions (the Sp mean floor and the
+    # constraint argmins).  A negligible padded_size-length vector, not a full-sino mask.
+    pl = ct_model.sino_placement
+    ax = ct_model.sinogram_shard_axis()
+    mask_shape = [1] * measured_sino.ndim
+    mask_shape[ax] = pl.padded_size
+    view_mask = (jnp.arange(pl.padded_size) < pl.real_size).reshape(mask_shape).astype(measured_sino.dtype)
+    num_real_pixels = pl.real_size * (measured_sino.size // measured_sino.shape[ax])
+
+    # Get normalized sinogram p and [m_0, m_1, ...] (view-sharded; forward_project handles placement).
     plastic_sino_est, metal_sino_est = _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model)
-    plastic_sino_scale = jnp.max(jnp.abs(plastic_sino_est))
+    plastic_sino_scale = jnp.max(jnp.abs(plastic_sino_est))   # max over padded 0s is unaffected
     metal_sino_scale = [jnp.max(jnp.abs(arr)) for arr in metal_sino_est]
     plastic_sino_est = plastic_sino_est / plastic_sino_scale
     metal_sino_est = [arr / norm for arr, norm in zip(metal_sino_est, metal_sino_scale)]
 
     # Estimate beam hardening model parameters theta
-    theta = _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H_exponent_list, num_cross_terms, alpha, beta, num_constraint_update_iter)
+    theta = _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H_exponent_list, num_cross_terms, alpha, beta, num_constraint_update_iter, view_mask=view_mask)
     # print(f'theta = {theta}')
 
     # Compute the corrected plastic sinogram
     plastic_sino_corrected = _correct_plastic_sinogram(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list,
-                                                       num_cross_terms, num_metal_terms, plastic_sino_scale, gamma)
+                                                       num_cross_terms, num_metal_terms, plastic_sino_scale, gamma,
+                                                       view_mask=view_mask, num_real_pixels=num_real_pixels)
 
     # Compute and apply the scaling of the corrected plastic sino
     plastic_sino_corrected_scale = _estimate_plastic_scaling(plastic_sino_est, metal_sino_est, measured_sino, plastic_sino_corrected)
     scaled_corrected_plastic_sino = plastic_sino_corrected_scale * plastic_sino_corrected
 
-    # Combine the scaled corrected plastic sino and the metal sinos
-    corrected_sino_flat = scaled_corrected_plastic_sino + sum(arr * norm for arr, norm in zip(metal_sino_est, metal_sino_scale))
-    corrected_sino = corrected_sino_flat.reshape(sino_shape)
-
-    return corrected_sino
+    # Combine the scaled corrected plastic sino and the metal sinos (all view-sharded), then gather to a
+    # host sinogram cropped to the real views (dropping padding) for the downstream recon.
+    corrected_sino = scaled_corrected_plastic_sino + sum(arr * norm for arr, norm in zip(metal_sino_est, metal_sino_scale))
+    return ct_model._gather_sinogram(corrected_sino)
 
 
 def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constraint_update_iter=10, stop_threshold_change_pct=0.5,

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -52,9 +52,19 @@ def gen_huber_weights(weights, sino_error, T=1.0, delta=1.0, epsilon=1e-6):
     if not (0.0 <= delta <= 1.0):
         raise ValueError("delta must be between 0 and 1.")
 
-    weights = jnp.asarray(weights)
-    sino_error = jnp.asarray(sino_error)
+    return _gen_huber_weights_kernel(jnp.asarray(weights), jnp.asarray(sino_error), T, delta, epsilon)
 
+
+@jax.jit
+def _gen_huber_weights_kernel(weights, sino_error, T, delta, epsilon):
+    """Jitted body of :func:`gen_huber_weights`.
+
+    Eagerly this chain materialized ~5 full-sinogram temporaries (std, the two norms' squares,
+    normalized_error, abs, where) and the two ``jnp.linalg.norm`` reductions each ran as separate
+    dispatches (with their own cross-device collectives on sharded inputs).  Jitted, XLA fuses the
+    elementwise chain into the reductions and the final ``where`` -- no full-size temporaries, one
+    executable.  (``jnp.linalg.norm`` with default ord is a pure XLA sum-of-squares reduction; it does
+    not call cuSolver.)"""
     # Compute std and global alpha
     std = 1.0 / jnp.maximum(jnp.sqrt(weights), epsilon)
     alpha = jnp.linalg.norm(sino_error) / (jnp.linalg.norm(std) + epsilon)
@@ -337,7 +347,7 @@ def _estimate_BH_model_params_using_OSQP(P, q, A, u):
         # No constraints - solve unconstrained QP directly.  The system is tiny (num_cols x num_cols),
         # so solve on the HOST with numpy, like the OSQP branch below: jnp.linalg.solve dispatches to
         # cuSolver on GPU, whose handle/workspace allocation lives OUTSIDE XLA's memory pool and fails
-        # when XLA has preallocated nearly all device memory (XLA_PYTHON_CLIENT_MEM_FRACTION=0.98) --
+        # when the pool has reserved nearly all device memory (XLA_PYTHON_CLIENT_MEM_FRACTION) --
         # an async failure that only surfaces when theta is first read.
         theta = np.linalg.solve(P_numpy, -q_numpy)
         return jnp.asarray(theta, dtype=jnp.float32)

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -469,7 +469,10 @@ def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H
             row_m = _get_row_H(i_min_residual, plastic_sino_est, metal_sino_est, H_exponent_list)
             # Positive row_m[dp:] to ensure y-Hmθm >= 0
             A_m = jnp.concatenate([jnp.zeros(dp), row_m[dp:]])
-            u_m = jnp.array([measured_sino[i_min_residual]])
+            # i_min_residual is a FLAT pixel index; the sinogram is 3-D (view-sharded), so read the one
+            # pixel through the flattened view (reshape preserves the sharding) -- integer-indexing the
+            # 3-D array would silently grab a whole VIEW along axis 0 instead.
+            u_m = jnp.array([measured_sino.reshape(-1)[i_min_residual]])
             A = jnp.vstack([A, A_m[None, :]])
             u = jnp.concatenate([u, u_m])
             C_m.append(i_min_residual)

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -155,7 +155,7 @@ def _generate_metal_exponent_list(num_metal, max_order):
     return combinations
 
 
-def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model, device):
+def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model):
     """
     Segment plastic and metal regions from a reconstruction, project them,
     and return the unnormalized sinogram p, m0, m1, ... for beam hardening modeling.
@@ -164,7 +164,6 @@ def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model, device):
         recon (jnp.ndarray): Reconstructed image.
         num_metal (int): Number of metal types to segment.
         ct_model: Forward projection model with a `.forward_project()` method.
-        device: JAX device to put the masks on for projection.
 
     Returns:
         plastic_sino_est (jnp.ndarray): Unnormalized plastic sino estimation.
@@ -178,12 +177,16 @@ def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model, device):
     plastic_mask, metal_masks, plastic_scale, metal_scales = mjp.segment_plastic_metal(recon, num_metal=num_metal)
 
     # --- Forward project, scale and vectorize plastic ---
-    plastic_sino_est = plastic_scale * ct_model.forward_project(jax.device_put(plastic_mask, device)).reshape(-1)
+    # forward_project shards its input internally (_shard_recon), so hand it the mask/masked-recon
+    # directly -- do NOT jax.device_put the recon-sized array onto one device first (that would gather
+    # the whole volume onto a single GPU, spiking memory and defeating the projector's sharding).
+    # plastic_mask / mask*recon inherit recon's layout (sharded stays sharded; host stays host).
+    plastic_sino_est = plastic_scale * ct_model.forward_project(plastic_mask).reshape(-1)
 
     # --- Forward project the masked out metal regions ---
     metal_sino_est = []
     for mask, scale in zip(metal_masks, metal_scales):
-        m = ct_model.forward_project(jax.device_put(mask * recon, device)).reshape(-1)
+        m = ct_model.forward_project(mask * recon).reshape(-1)
         metal_sino_est.append(m)
 
     return plastic_sino_est, metal_sino_est
@@ -551,12 +554,12 @@ def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, orde
             [(1, *t) for t in cross_exponent_list] +
             [(0, *t) for t in metal_exponent_list])
 
-    device = ct_model.recon_placement.devices[0]
     sino_shape = measured_sino.shape
     measured_sino = measured_sino.reshape(-1)
 
-    # Get normalized sinogram p and [m_0, m_1, ...]
-    plastic_sino_est, metal_sino_est = _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model, device)
+    # Get normalized sinogram p and [m_0, m_1, ...].  forward_project inside handles device placement
+    # (sharding internally); nothing is gathered onto a single device here.
+    plastic_sino_est, metal_sino_est = _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model)
     plastic_sino_scale = jnp.max(jnp.abs(plastic_sino_est))
     metal_sino_scale = [jnp.max(jnp.abs(arr)) for arr in metal_sino_est]
     plastic_sino_est = plastic_sino_est / plastic_sino_scale

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -330,8 +330,13 @@ def _estimate_BH_model_params_using_OSQP(P, q, A, u):
         jnp.ndarray: Solution vector θ.
     """
     if A is None or u is None:
-        # No constraints - solve unconstrained QP directly
-        return jnp.linalg.solve(P, -q)
+        # No constraints - solve unconstrained QP directly.  The system is tiny (num_cols x num_cols),
+        # so solve on the HOST with numpy, like the OSQP branch below: jnp.linalg.solve dispatches to
+        # cuSolver on GPU, whose handle/workspace allocation lives OUTSIDE XLA's memory pool and fails
+        # when XLA has preallocated nearly all device memory (XLA_PYTHON_CLIENT_MEM_FRACTION=0.98) --
+        # an async failure that only surfaces when theta is first read.
+        theta = np.linalg.solve(np.asarray(P), -np.asarray(q))
+        return jnp.asarray(theta, dtype=jnp.float32)
 
     # Convert arrays as required by OSQP. These matrices are small.
     P_numpy = np.asarray(P)

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -1,6 +1,7 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import functools
 import mbirjax as mj
 import mbirjax.preprocess as mjp
 from . import pipeline
@@ -161,19 +162,31 @@ def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model):
         plastic_sino_est (jnp.ndarray): Unnormalized plastic sino estimation.
         metal_sino_est (list of jnp.ndarray): List of unnormalized metal sino estimation.
     """
+    # Shard the recon once at entry (a no-op if it is already sharded, e.g. from a recon with
+    # output_sharded=True).  The segmentation then runs on-device across the shards -- including the
+    # Otsu histogram, which reduces per-shard partial histograms without gathering the volume -- and the
+    # 1+num_metal forward projections below consume the SAME sharded recon instead of re-uploading a
+    # recon-sized array per mask.
+    recon = ct_model._shard_recon(recon)
+
+    # Slice-padding info: the sharded recon may be zero-padded on the slice axis (to divide evenly
+    # across devices).  valid_mask (True on real slices; broadcastable, tiny; None when unpadded) and
+    # num_real_slices let the segmentation exclude the padded slices from its statistics and masks.
+    pl = ct_model.recon_placement
+    valid_mask = pl.real_mask(recon.ndim)
+
     # --- Segment plastic and metal regions in the reconstruction ---
     # plastic_mask: Mask for plastic regions.
     # metal_masks: List of masks for each metal.
     # plastic_scale: Scaling factor for the plastic region.
     # metal_scales: List of scaling factors for each metal region.
-    plastic_mask, metal_masks, plastic_scale, metal_scales = mjp.segment_plastic_metal(recon, num_metal=num_metal)
+    plastic_mask, metal_masks, plastic_scale, metal_scales = mjp.segment_plastic_metal(
+        recon, num_metal=num_metal, valid_mask=valid_mask, num_real_slices=pl.real_size)
 
     # --- Forward project and scale plastic ---
-    # forward_project shards its input internally (_shard_recon), so hand it the mask/masked-recon
-    # directly -- do NOT jax.device_put the recon-sized array onto one device first.  Keep the OUTPUT
-    # view-sharded (output_sharded=True) and do NOT flatten: the whole correction below runs on these
-    # sharded 3-D sinograms so no full-length sino vector ever lands on a single device.  (plastic_mask /
-    # mask*recon inherit recon's layout; the sino outputs are view-sharded per sino_placement.)
+    # The masks/recon are already sharded, so forward_project consumes them with no further movement.
+    # Keep the OUTPUT view-sharded (output_sharded=True) and do NOT flatten: the whole correction below
+    # runs on these sharded 3-D sinograms so no full-length sino vector ever lands on a single device.
     plastic_sino_est = plastic_scale * ct_model.forward_project(plastic_mask, output_sharded=True)
 
     # --- Forward project the masked out metal regions ---
@@ -273,8 +286,8 @@ def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_
     # Lower-bound violator: minimize Sp and y-Sm over the REAL views (padded views set to +inf so they
     # can't win the argmin).  argmin over the N-D sinogram returns a FLAT index; read the values back via
     # the flattened view (reshape(-1) preserves the sharding).
-    Sp_masked = Sp if view_mask is None else jnp.where(view_mask > 0, Sp, jnp.inf)
-    ymSm_masked = y_minus_Sm if view_mask is None else jnp.where(view_mask > 0, y_minus_Sm, jnp.inf)
+    Sp_masked = Sp if view_mask is None else jnp.where(view_mask, Sp, jnp.inf)
+    ymSm_masked = y_minus_Sm if view_mask is None else jnp.where(view_mask, y_minus_Sm, jnp.inf)
     i_min_Sp = int(jnp.argmin(Sp_masked))
     i_min_residual = int(jnp.argmin(ymSm_masked))
 
@@ -579,14 +592,13 @@ def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, orde
     # (output_sharded=True), so every step is a per-shard elementwise op or a cross-device reduction.
     measured_sino = ct_model.prepare_sino_for_devices(measured_sino)
 
-    # Real-view mask (1 on real views, 0 on padded) broadcasting over the shard axis, plus the real pixel
-    # count -- used to exclude padded views from the statistical reductions (the Sp mean floor and the
-    # constraint argmins).  A negligible padded_size-length vector, not a full-sino mask.
+    # Real-view mask (True on real views, False on padded; None when unpadded) broadcasting over the
+    # shard axis, plus the real pixel count -- used to exclude padded views from the statistical
+    # reductions (the Sp mean floor and the constraint argmins).  A negligible padded_size-length
+    # vector, not a full-sino mask.
     pl = ct_model.sino_placement
-    ax = ct_model.sinogram_shard_axis()
-    mask_shape = [1] * measured_sino.ndim
-    mask_shape[ax] = pl.padded_size
-    view_mask = (jnp.arange(pl.padded_size) < pl.real_size).reshape(mask_shape).astype(measured_sino.dtype)
+    view_mask = pl.real_mask(measured_sino.ndim)
+    ax = ct_model.sinogram_shard_axis() % measured_sino.ndim
     num_real_pixels = pl.real_size * (measured_sino.size // measured_sino.shape[ax])
 
     # Get normalized sinogram p and [m_0, m_1, ...] (view-sharded; forward_project handles placement).
@@ -616,7 +628,7 @@ def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, orde
 
 
 def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constraint_update_iter=10, stop_threshold_change_pct=0.5,
-                        num_metal=1, order=3, alpha=1, beta=0.002, gamma=0.1, verbose=0):
+                        num_metal=1, order=3, alpha=1, beta=0.002, gamma=0.1, verbose=0, output_sharded=False):
     """
     Perform iterative metal artifact reduction using plastic-metal beam hardening correction.  If num_metal is 0,
     then this performs a standard MBIR recon.
@@ -640,9 +652,13 @@ def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constr
         gamma (float, optional): Stabilization factor used in plastic correction. Multiplies the median of `s_p`
             to set a positive floor in the denominator, preventing division by near-zero or negative values. Defaults to 0.1.
         verbose (int, optional): Verbosity level for printing intermediate information. Defaults to 0.
+        output_sharded (bool, optional): Choose the form of the returned reconstruction.  If False
+            (default), return an ordinary host NumPy array.  If True, leave it distributed
+            (slice-sharded) across the model's devices for a following on-device step.
 
     Returns:
-         jnp.ndarray: The final corrected reconstruction after iterative beam hardening correction.
+         numpy or jax array: The final corrected reconstruction after iterative beam hardening
+         correction -- a host NumPy array by default, or slice-sharded if ``output_sharded=True``.
 
     Example:
         >>> recon = recon_plastic_metal(
@@ -661,20 +677,30 @@ def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constr
     if num_metal < 0:
         raise ValueError("num_metal must be >= 0")
 
-    # Use split sino recon by default for cone beam
-    recon_function = ct_model.recon
+    # Use split sino recon by default for cone beam.  recon() keeps its output SHARDED (the next
+    # correction consumes it on-device with no gather/re-upload); split_sino_recon returns a host recon
+    # BY DESIGN (it splits on the host so the full sinogram is never device-resident) -- the next
+    # correction re-shards it at entry (one upload; device-side stitching is a possible follow-up).
+    # Either form converges at correct_sino_plastic_metal / the exit adapter below.
     if 'ConeBeamModel' in ct_model.get_params('geometry_type'):
         recon_function = ct_model.split_sino_recon
+    else:
+        recon_function = functools.partial(ct_model.recon, output_sharded=True)
+
+    # Deliver the user-requested output form: _shard_recon / _gather_recon are each a no-op when the
+    # loop's final recon is already in that form.
+    def to_output_form(r):
+        return ct_model._shard_recon(r) if output_sharded else ct_model._gather_recon(r)
 
     # Do a regular recon if num_metal == 0
     if num_metal == 0:
         recon, _ = recon_function(sino, weights=weights, stop_threshold_change_pct=stop_threshold_change_pct)
-        return recon
+        return to_output_form(recon)
 
     # Continue with beam hardening and segmentation
     if verbose >= 1:
         print("\n************ Perform initial FDK reconstruction  **************")
-    recon = ct_model.direct_recon(sino)
+    recon = ct_model.direct_recon(sino, output_sharded=True)
 
     for i in range(num_BH_iterations):
         # Estimate Corrected Sinogram
@@ -693,4 +719,4 @@ def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constr
                             slice_label=labels,
                             title=f'Iteration {i + 1}: Comparison of Plastic and Metal Masks')
 
-    return recon
+    return to_output_form(recon)

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -244,12 +244,18 @@ def _get_column_H(col_index, plastic_sino_est, metal_sino_est, H_exponent_list):
         col = jnp.ones_like(plastic_sino_est)
     return col
 
-def _get_row_H(row_index, plastic_sino_est, metal_sino_est, H_exponent_list):
+def _get_row_H(pixel_index, plastic_sino_est, metal_sino_est, H_exponent_list):
     """
-    Compute the row_index-th row of the matrix H.
+    Compute the row of the matrix H for one sinogram pixel.
+
+    H is conceptually (num_pixels x num_cols) -- one row per sinogram pixel -- so ``pixel_index``
+    specifies a ROW of H.  It is named for the pixel rather than the matrix row because it is a
+    (view, row, col) tuple whose middle entry is the DETECTOR row, a different axis.
 
     Args:
-        row_index (int): Index of the row to compute.
+        pixel_index (tuple of int): (view, row, col) of the pixel, identifying the row of H to compute
+            (per-axis Python ints -- flat indices are never used on the full sinogram: a flat axis
+            longer than 2^31 forces truncated int64 index arithmetic; see _argmin_3d).
         plastic_sino_est (jnp.ndarray): Normalized plastic sinogram estimation.
         metal_sino_est (list of jnp.ndarray): Normalized metal sinogram estimation [m_0, m_1, ..., m_{n-1}].
         H_exponent_list (list of tuple): List of exponent tuples defining each column of H.
@@ -257,11 +263,8 @@ def _get_row_H(row_index, plastic_sino_est, metal_sino_est, H_exponent_list):
     Returns:
         jnp.ndarray: The computed row of H.
     """
-    # row_index is a FLAT pixel index (from argmin over the flattened sinogram); the sinos are now 3-D
-    # (view-sharded), so index the flattened view (reshape(-1) preserves the sharding; this is a
-    # single-element gather).
-    pi = plastic_sino_est.reshape(-1)[row_index]
-    mi = [m.reshape(-1)[row_index] for m in metal_sino_est]
+    pi = plastic_sino_est[pixel_index]
+    mi = [m[pixel_index] for m in metal_sino_est]
     row_vals = []
     for exps in H_exponent_list:
         val = (pi ** exps[0])
@@ -269,6 +272,28 @@ def _get_row_H(row_index, plastic_sino_est, metal_sino_est, H_exponent_list):
             val = val * (mk ** ek)
         row_vals.append(val)
     return jnp.asarray(row_vals)
+
+
+def _argmin_3d(x):
+    """Index of the minimum of a 3-D sinogram-shaped array as PER-AXIS Python ints (view, row, col),
+    plus the minimum value (a device scalar).
+
+    Equivalent to unraveling ``jnp.argmin(x)``, but safe for arrays with more than 2^31 elements:
+    ``lax.argmin`` computes its index labels in int32 (with x64 disabled), so a FLAT argmin over a
+    full-size sinogram silently WRAPS for minima beyond flat position 2^31 -- verified: a minimum
+    planted at 2.3e9 returns -1,994,967,296 (off by exactly 2^32) with no warning -- and flat reads on
+    such an axis need int64 indices that are truncated (the "int64 ... truncated to int32" UserWarning).
+    Staging the argmin per axis keeps every index within its own small axis length (detector plane
+    positions < rows*cols, view index < num_views), all safely int32.  Tie-breaking matches the flat
+    row-major argmin: the first view attaining the minimum, and the first plane position within it.
+    """
+    num_views, num_rows, num_channels = x.shape
+    per_view = x.reshape(num_views, -1)              # (V, R*C); preserves view-sharding
+    per_view_min = jnp.min(per_view, axis=1)         # (V,) per-shard local reduce
+    plane_argmin = jnp.argmin(per_view, axis=1)      # (V,) int32; every value < R*C << 2^31
+    view = int(jnp.argmin(per_view_min))             # V << 2^31
+    row, col = divmod(int(plane_argmin[view]), num_channels)
+    return (view, row, col), per_view_min[view]
 
 
 def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms, view_mask=None):
@@ -285,10 +310,11 @@ def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_
     padded views from the argmin so a padded entry is never selected as a constraint.
 
     Returns:
-        i_min_Sp (int): FLAT index of smallest Sp entry (into the flattened sinogram).
-        v_min_Sp (float): Value of Sp at that entry.
-        i_min_residual (int): FLAT index of smallest (y − Sm) entry.
-        v_min_residual (float): Value of (y − Sm) at that entry.
+        idx_min_Sp (tuple of int): (view, row, col) of the smallest Sp entry (per-axis ints; see
+            ``_argmin_3d`` for why flat indices are unsafe on full-size sinograms).
+        v_min_Sp (scalar): Value of Sp at that entry.
+        idx_min_residual (tuple of int): (view, row, col) of the smallest (y − Sm) entry.
+        v_min_residual (scalar): Value of (y − Sm) at that entry.
     """
     num_cols = len(H_exponent_list)
     # The coefficient of p in column i is the column with its p factor removed, so zero the p exponent
@@ -306,17 +332,15 @@ def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_
         y_minus_Sm = y_minus_Sm - theta[j] * _get_column_H(j, plastic_sino_est, metal_sino_est, H_exponent_list)
 
     # Lower-bound violator: minimize Sp and y-Sm over the REAL views (padded views set to +inf so they
-    # can't win the argmin).  argmin over the N-D sinogram returns a FLAT index; read the values back via
-    # the flattened view (reshape(-1) preserves the sharding).
+    # can't win the argmin).  _argmin_3d returns per-axis (view, row, col) ints plus the value -- the
+    # value at a real position is the same in the masked and unmasked arrays (the mask only alters
+    # padded entries), so no separate read is needed.
     Sp_masked = Sp if view_mask is None else jnp.where(view_mask, Sp, jnp.inf)
     ymSm_masked = y_minus_Sm if view_mask is None else jnp.where(view_mask, y_minus_Sm, jnp.inf)
-    i_min_Sp = int(jnp.argmin(Sp_masked))
-    i_min_residual = int(jnp.argmin(ymSm_masked))
+    idx_min_Sp, v_min_Sp = _argmin_3d(Sp_masked)
+    idx_min_residual, v_min_residual = _argmin_3d(ymSm_masked)
 
-    v_min_Sp = Sp.reshape(-1)[i_min_Sp]
-    v_min_residual = y_minus_Sm.reshape(-1)[i_min_residual]
-
-    return i_min_Sp, v_min_Sp, i_min_residual, v_min_residual
+    return idx_min_Sp, v_min_Sp, idx_min_residual, v_min_residual
 
 
 
@@ -458,34 +482,31 @@ def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H
     theta = _estimate_BH_model_params_using_OSQP(P, q, A=None, u=None)
 
     for iter in range(num_constraint_update_iter):
-        # Find the indices and values of the points that most violate each constraint
-        i_min_Sp, v_min_Sp, i_min_residual, v_min_residual = _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms, view_mask=view_mask)
+        # Find the (view, row, col) indices and values of the points that most violate each constraint
+        idx_min_Sp, v_min_Sp, idx_min_residual, v_min_residual = _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms, view_mask=view_mask)
 
         # (1) Hp θp ≥ 0  ->  (-Hp) θ ≤ 0
-        if v_min_Sp < tolerance and (i_min_Sp not in C_p):
+        if v_min_Sp < tolerance and (idx_min_Sp not in C_p):
             # Coefficient-of-p row: zero the p exponent (pi**0 == 1 exactly) instead of allocating a
             # full-sinogram dummy ones array just to read its one pixel.
             p_coeff_exponents = [(0,) + exps[1:] for exps in H_exponent_list]
-            row_p = _get_row_H(i_min_Sp, plastic_sino_est, metal_sino_est, p_coeff_exponents)
+            row_p = _get_row_H(idx_min_Sp, plastic_sino_est, metal_sino_est, p_coeff_exponents)
             # Negative row_p[:dp] to ensure Hpθp >= 0
             A_p = jnp.concatenate([-row_p[:dp], jnp.zeros((num_cols - dp,))])
             u_p = jnp.array([0.0])
             A = jnp.vstack([A, A_p[None, :]])
             u = jnp.concatenate([u, u_p])
-            C_p.append(i_min_Sp)
+            C_p.append(idx_min_Sp)
 
         # (2) y − Hm θm ≥ 0  ->  (Hm) θ ≤ y
-        if v_min_residual < tolerance and (i_min_residual not in C_m):
-            row_m = _get_row_H(i_min_residual, plastic_sino_est, metal_sino_est, H_exponent_list)
+        if v_min_residual < tolerance and (idx_min_residual not in C_m):
+            row_m = _get_row_H(idx_min_residual, plastic_sino_est, metal_sino_est, H_exponent_list)
             # Positive row_m[dp:] to ensure y-Hmθm >= 0
             A_m = jnp.concatenate([jnp.zeros(dp), row_m[dp:]])
-            # i_min_residual is a FLAT pixel index; the sinogram is 3-D (view-sharded), so read the one
-            # pixel through the flattened view (reshape preserves the sharding) -- integer-indexing the
-            # 3-D array would silently grab a whole VIEW along axis 0 instead.
-            u_m = jnp.array([measured_sino.reshape(-1)[i_min_residual]])
+            u_m = jnp.array([measured_sino[idx_min_residual]])
             A = jnp.vstack([A, A_m[None, :]])
             u = jnp.concatenate([u, u_m])
-            C_m.append(i_min_residual)
+            C_m.append(idx_min_residual)
 
         # Early exit if both constraints are satisfied (within tolerances)
         if (v_min_Sp >= tolerance) and (v_min_residual >= tolerance):

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -219,10 +219,19 @@ def _get_column_H(col_index, plastic_sino_est, metal_sino_est, H_exponent_list):
     exponents = H_exponent_list[col_index]
     assert len(exponents) == 1 + len(metal_sino_est), "Mismatch between exponent tuple and number of sinograms."
 
-    col = plastic_sino_est ** exponents[0]
-    for metal, exp in zip(metal_sino_est, exponents[1:]):
-        col *= metal ** exp
-
+    # Most exponents are 0 or 1 (the exponent tuples are sparse), so skip the no-op factors instead of
+    # materializing full-sinogram-sized ones/copies: x**0 == 1 exactly (skip the factor) and x**1 == x
+    # exactly (use the array directly, no power op).  Byte-identical to the dense product.
+    col = None
+    for arr, exp in zip([plastic_sino_est] + list(metal_sino_est), exponents):
+        if exp == 0:
+            continue
+        term = arr if exp == 1 else arr ** exp
+        col = term if col is None else col * term
+    if col is None:
+        # All-zero exponent tuple (the constant column) -- excluded by construction from H, but handle
+        # it correctly if a caller ever asks.
+        col = jnp.ones_like(plastic_sino_est)
     return col
 
 def _get_row_H(row_index, plastic_sino_est, metal_sino_est, H_exponent_list):

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -201,7 +201,7 @@ def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model):
 
     # --- Forward project the masked out metal regions ---
     metal_sino_est = []
-    for mask, scale in zip(metal_masks, metal_scales):
+    for mask in metal_masks:
         m = ct_model.forward_project(mask * recon, output_sharded=True)
         metal_sino_est.append(m)
 

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -755,6 +755,8 @@ def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constr
 
     for i in range(num_BH_iterations):
         # Estimate Corrected Sinogram
+        if verbose >= 1:
+            print(f"\n************ Correct sino plastic metal {i + 1}  **************")
         corrected_sinogram = correct_sino_plastic_metal(ct_model, sino, recon, num_metal=num_metal, order=order, alpha=alpha, beta=beta, gamma=gamma, num_constraint_update_iter=num_constraint_update_iter)
 
         # Reconstruct Corrected Sinogram

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -281,10 +281,13 @@ def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_
         v_min_residual (float): Value of (y − Sm) at that entry.
     """
     num_cols = len(H_exponent_list)
+    # The coefficient of p in column i is the column with its p factor removed, so zero the p exponent
+    # (the sparse _get_column_H then SKIPS that factor) rather than passing a dummy full-sinogram ones
+    # array -- eagerly, the ones would be reallocated (and multiplied) on every loop iteration.
+    p_coeff_exponents = [(0,) + exps[1:] for exps in H_exponent_list]
     Sp = jnp.zeros_like(measured_sino)
     for i in range(0, 1 + num_cross_terms):
-        # Use a dummy input of ones to extract the structure of the i-th column (i.e., coefficient of p)
-        Sp = Sp + theta[i] * _get_column_H(i, jnp.ones_like(plastic_sino_est), metal_sino_est, H_exponent_list)
+        Sp = Sp + theta[i] * _get_column_H(i, plastic_sino_est, metal_sino_est, p_coeff_exponents)
 
     # y_minus_Sm = y - metal-only
     y_minus_Sm = measured_sino
@@ -443,7 +446,10 @@ def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H
 
         # (1) Hp θp ≥ 0  ->  (-Hp) θ ≤ 0
         if v_min_Sp < tolerance and (i_min_Sp not in C_p):
-            row_p = _get_row_H(i_min_Sp, jnp.ones_like(measured_sino), metal_sino_est, H_exponent_list)
+            # Coefficient-of-p row: zero the p exponent (pi**0 == 1 exactly) instead of allocating a
+            # full-sinogram dummy ones array just to read its one pixel.
+            p_coeff_exponents = [(0,) + exps[1:] for exps in H_exponent_list]
+            row_p = _get_row_H(i_min_Sp, plastic_sino_est, metal_sino_est, p_coeff_exponents)
             # Negative row_p[:dp] to ensure Hpθp >= 0
             A_p = jnp.concatenate([-row_p[:dp], jnp.zeros((num_cols - dp,))])
             u_p = jnp.array([0.0])
@@ -503,11 +509,14 @@ def _correct_plastic_sinogram(measured_sino, plastic_sino_est, metal_sino_est, t
         corrected_plastic_sino (jnp.ndarray): Beam-hardening-corrected plastic sinogram.
     """
 
-    # Compute the denominator (linear plastic + cross terms) from the first (1 + num_cross_terms) columns of H
+    # Compute the denominator (linear plastic + cross terms) from the first (1 + num_cross_terms) columns
+    # of H.  The coefficient of p in column i is the column with its p factor removed, so zero the p
+    # exponent (the sparse _get_column_H then SKIPS that factor) rather than passing a dummy
+    # full-sinogram ones array -- eagerly, the ones would be reallocated on every loop iteration.
+    p_coeff_exponents = [(0,) + exps[1:] for exps in H_exponent_list]
     Sp = jnp.zeros_like(measured_sino)
     for i in range(0, 1 + num_cross_terms):
-        # Use a dummy input of ones to extract the structure of the i-th column (i.e., coefficient of p)
-        Sp += theta[i] * _get_column_H(i, jnp.ones_like(measured_sino), metal_sino_est, H_exponent_list)
+        Sp += theta[i] * _get_column_H(i, plastic_sino_est, metal_sino_est, p_coeff_exponents)
 
     y_minus_Sm = measured_sino
     # Subtract metal-only terms (from H columns after the cross terms)

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -605,6 +605,19 @@ def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, orde
     plastic_sino_est, metal_sino_est = _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model)
     plastic_sino_scale = jnp.max(jnp.abs(plastic_sino_est))   # max over padded 0s is unaffected
     metal_sino_scale = [jnp.max(jnp.abs(arr)) for arr in metal_sino_est]
+    # JAX division does not raise on 0/0 -- an empty (all-zero) plastic or metal estimate would silently
+    # fill the normalized sinogram with NaNs and fail far downstream.  Check the scales explicitly (a
+    # scalar sync each, once per correction) and fail fast with an actionable message.  ``not > 0`` also
+    # catches a NaN scale (e.g. a NaN in the recon).
+    if not float(plastic_sino_scale) > 0:
+        raise ValueError(
+            "The estimated plastic sinogram is empty (the plastic segmentation class contains no "
+            "voxels).  Check the input reconstruction, num_metal, and the cylindrical-mask margins.")
+    for metal_index, scale in enumerate(metal_sino_scale):
+        if not float(scale) > 0:
+            raise ValueError(
+                f"The estimated sinogram for metal {metal_index} is empty (its segmentation class "
+                f"contains no voxels).  num_metal={num_metal} may be too large for this object.")
     plastic_sino_est = plastic_sino_est / plastic_sino_scale
     metal_sino_est = [arr / norm for arr, norm in zip(metal_sino_est, metal_sino_scale)]
 

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -329,18 +329,20 @@ def _estimate_BH_model_params_using_OSQP(P, q, A, u):
     Returns:
         jnp.ndarray: Solution vector θ.
     """
+    # Convert to numpy for linalg.solve and OSQP
+    P_numpy = np.asarray(P)
+    q_numpy = np.asarray(q)
+
     if A is None or u is None:
         # No constraints - solve unconstrained QP directly.  The system is tiny (num_cols x num_cols),
         # so solve on the HOST with numpy, like the OSQP branch below: jnp.linalg.solve dispatches to
         # cuSolver on GPU, whose handle/workspace allocation lives OUTSIDE XLA's memory pool and fails
         # when XLA has preallocated nearly all device memory (XLA_PYTHON_CLIENT_MEM_FRACTION=0.98) --
         # an async failure that only surfaces when theta is first read.
-        theta = np.linalg.solve(np.asarray(P), -np.asarray(q))
+        theta = np.linalg.solve(P_numpy, -q_numpy)
         return jnp.asarray(theta, dtype=jnp.float32)
 
     # Convert arrays as required by OSQP. These matrices are small.
-    P_numpy = np.asarray(P)
-    q_numpy = np.asarray(q)
     A_numpy = np.asarray(A)
     u_numpy = np.asarray(u)
 

--- a/mbirjax/preprocess/segmentation.py
+++ b/mbirjax/preprocess/segmentation.py
@@ -1,4 +1,5 @@
 import functools
+import math
 import numpy as np
 import jax
 import jax.numpy as jnp
@@ -79,7 +80,7 @@ def _iter_local_blocks(image, valid_mask):
 def _iter_slabs(block, mask_block):
     """Split a local block into leading-axis slabs of at most ``_HISTOGRAM_SLAB_ELEMENTS`` elements
     (the mask slabs along too, unless broadcast on that axis)."""
-    per_row = max(1, int(np.prod(block.shape[1:])))
+    per_row = max(1, math.prod(block.shape[1:]))   # exact Python ints (np.prod can wrap on Windows)
     rows_per_slab = max(1, _HISTOGRAM_SLAB_ELEMENTS // per_row)
     for j in range(0, block.shape[0], rows_per_slab):
         mask_slab = mask_block if mask_block.shape[0] == 1 else mask_block[j:j + rows_per_slab]

--- a/mbirjax/preprocess/segmentation.py
+++ b/mbirjax/preprocess/segmentation.py
@@ -20,21 +20,121 @@ def _masked_histogram(image, valid_mask, num_bins, xp):
     lo = xp.min(xp.where(valid_mask, image, inf))
     hi = xp.max(xp.where(valid_mask, image, -inf))
     sentinel = hi + xp.maximum(xp.abs(hi), xp.asarray(1.0, dtype=image.dtype))  # finite, strictly > hi
-    return xp.histogram(xp.where(valid_mask, image, sentinel), bins=num_bins, range=(lo, hi))
+    # Python-float range endpoints: numpy computes the bin edges in the RANGE's dtype, so float
+    # endpoints give the f64-computed, image-dtype-cast edges -- the same edges the sharded path
+    # computes -- whereas f32 endpoints would shift some edges by a few ULP.
+    return xp.histogram(xp.where(valid_mask, image, sentinel), bins=num_bins, range=(float(lo), float(hi)))
 
 
-@functools.partial(jax.jit, static_argnums=2)   # num_bins sets the output shape -> compile constant
+@jax.jit
+def _masked_min_max(image, valid_mask):
+    """Masked min/max of a (possibly sharded) volume -- pure reductions (cross-device all-reduce,
+    no gathers).  Constants typed to the image dtype so the where cannot upcast."""
+    inf = jnp.asarray(jnp.inf, dtype=image.dtype)
+    lo = jnp.min(jnp.where(valid_mask, image, inf))
+    hi = jnp.max(jnp.where(valid_mask, image, -inf))
+    return lo, hi
+
+
+@functools.partial(jax.jit, static_argnums=4)
+def _local_bucketize_histogram(image, valid_mask, lo, hi, num_bins):
+    """Single-device masked histogram by explicit bucketize + scatter-add (see _sharded_histogram).
+
+    In-range values map to bin ``floor(num_bins * (x - lo) / span)``; ``hi`` itself maps to
+    ``num_bins`` and is clipped into the last bin, matching ``np.histogram``'s closed last edge.
+    Invalid / out-of-range entries get an arbitrary in-range index but contribute 0 via the mask.
+    Counts accumulate in int32 -- exact because callers pass SLABS below 2^31 elements (see
+    ``_HISTOGRAM_SLAB_ELEMENTS``); the exact int64 total is accumulated on the host."""
+    span = jnp.maximum(hi - lo, jnp.asarray(jnp.finfo(image.dtype).tiny, dtype=image.dtype))
+    idx = jnp.clip((num_bins * (image - lo) / span).astype(jnp.int32), 0, num_bins - 1)
+    contrib = (valid_mask & (image >= lo) & (image <= hi)).astype(jnp.int32)
+    return jnp.zeros(num_bins, dtype=jnp.int32).at[idx.reshape(-1)].add(contrib.reshape(-1))
+
+
+# Per-slab element budget for the on-device histogram: bounds the bucketize's int32 index/contribution
+# temporaries (~2 GB at 2^28) and, more importantly, guarantees every slab's int32 counts are EXACT
+# (a slab bin cannot exceed the slab size < 2^31).
+_HISTOGRAM_SLAB_ELEMENTS = 2 ** 28
+
+
+def _iter_local_blocks(image, valid_mask):
+    """Yield ``(block, mask_block)``: each device's LOCAL shard of ``image`` (device-resident jax
+    array; no cross-device movement) with the matching broadcastable piece of ``valid_mask``.
+
+    Shards are deduplicated by their global index so a replicated (or single-device) array yields its
+    data exactly once -- nothing is double counted."""
+    mask = np.asarray(valid_mask)
+    seen = set()
+    for shard in image.addressable_shards:
+        key = tuple((s.start, s.stop, s.step) for s in shard.index)
+        if key in seen:
+            continue
+        seen.add(key)
+        # The mask follows the shard's global slice only on axes where it has real extent; its size-1
+        # (broadcast) axes are kept whole.
+        sel = tuple(idx if mask.shape[i] != 1 else slice(None) for i, idx in enumerate(shard.index))
+        yield shard.data, mask[sel]
+
+
+def _iter_slabs(block, mask_block):
+    """Split a local block into leading-axis slabs of at most ``_HISTOGRAM_SLAB_ELEMENTS`` elements
+    (the mask slabs along too, unless broadcast on that axis)."""
+    per_row = max(1, int(np.prod(block.shape[1:])))
+    rows_per_slab = max(1, _HISTOGRAM_SLAB_ELEMENTS // per_row)
+    for j in range(0, block.shape[0], rows_per_slab):
+        mask_slab = mask_block if mask_block.shape[0] == 1 else mask_block[j:j + rows_per_slab]
+        yield block[j:j + rows_per_slab], mask_slab
+
+
 def _sharded_histogram(image, valid_mask, num_bins=1024):
-    """Jitted :func:`_masked_histogram` for a (possibly view/slice-sharded) jax volume.
+    """Masked histogram of a (possibly view/slice-sharded) jax volume, matching
+    ``np.histogram(valid entries, num_bins, range=(min, max))``, with EXACT int64 counts.
 
-    A histogram is sum-decomposable (``hist(x) = sum over shards of hist(x_shard)``, integer counts), so
-    on a sharded array XLA compiles this to per-shard partial histograms + an all-reduce of the tiny
-    ``(num_bins,)`` output -- verified 0 all-gathers.  min/max are likewise exact all-reduces (order
-    insensitive), so the result is bit-identical to the host computation on the valid entries.
+    A histogram is sum-decomposable (``hist(x) = sum over pieces of hist(piece)``, integer counts), and
+    the decomposition is enforced explicitly: each device's LOCAL shard block is histogrammed on its own
+    device in slabs (int32, exact within a slab), and the tiny ``(num_bins,)`` partials are combined on
+    the HOST in int64 -- exact at any volume size, with no cross-device collectives at all (the masked
+    min/max combine on the host too; min/max are order-free).  All slabs are dispatched asynchronously
+    before any result is read, so the devices overlap without threads.
 
-    Returns (hist, bin_edges) as device arrays (tiny; callers convert to host).
+    Two approaches are deliberately NOT used: (1) ``jnp.histogram`` or a global ``.at[idx].add`` scatter
+    on the sharded array -- GSPMD does not partition scatter and lowers both with all-gathers of the
+    IMAGE-SIZED index/update arrays onto every device (observed as a 47 GiB allocation on an ~18 GiB
+    sharded recon); (2) ``shard_map`` -- it invokes XLA's SPMD partitioner, whose lowering has bitten
+    this codebase before (see ``experiments/sharding/parallel_performance/fbp_parallel_options.md``);
+    the per-device local pattern used here matches the fbp filter and the preprocessing driver.
+
+    Semantics vs ``np.histogram``: range = masked min/max; invalid/out-of-range entries dropped; ``hi``
+    lands in the last (closed) bin.  A value exactly on an interior bin edge can differ from numpy's
+    edge arithmetic by one bin (float rounding of the scaled index) -- irrelevant at Otsu's bin
+    granularity.
+
+    Returns:
+        (hist, bin_edges): host numpy arrays -- int64 counts and float64 edges (as ``np.histogram``).
     """
-    return _masked_histogram(image, valid_mask, num_bins, jnp)
+    blocks = list(_iter_local_blocks(image, valid_mask))
+
+    # Pass 1: masked min/max per slab; dispatch everything, then read; combine exactly on the host.
+    pending = [_masked_min_max(slab, mask_slab)
+               for block, mask_block in blocks for slab, mask_slab in _iter_slabs(block, mask_block)]
+    lo = min(float(lo_hi[0]) for lo_hi in pending)
+    hi = max(float(lo_hi[1]) for lo_hi in pending)
+
+    # Pass 2: bucketize + scatter per slab (int32, exact within a slab); accumulate on the host in
+    # int64.  lo/hi are passed as image-dtype scalars so the kernel's arithmetic stays in that dtype.
+    lo_dev = np.asarray(lo, dtype=image.dtype)
+    hi_dev = np.asarray(hi, dtype=image.dtype)
+    pending = [_local_bucketize_histogram(slab, mask_slab, lo_dev, hi_dev, num_bins)
+               for block, mask_block in blocks for slab, mask_slab in _iter_slabs(block, mask_block)]
+    hist = np.zeros(num_bins, dtype=np.int64)
+    for partial in pending:
+        hist += np.asarray(partial, dtype=np.int64)
+
+    # Edges computed on the host exactly as np.histogram does -- a linspace in the image's dtype
+    # (np.histogram's bin_type is result_type(range, data)) -- so the np and jax paths of
+    # multi_threshold_otsu produce identical edges for identical data.
+    bin_edges = np.linspace(lo, hi, num_bins + 1, dtype=image.dtype)
+    return hist, bin_edges
 
 
 def multi_threshold_otsu(image, classes=2, num_bins=1024, valid_mask=None):
@@ -78,17 +178,18 @@ def multi_threshold_otsu(image, classes=2, num_bins=1024, valid_mask=None):
     if num_bins < classes:
         raise ValueError("Number of bins must be at least equal to number of classes")
 
-    # Compute the histogram of the valid entries: on-device (sharded-safe) for a jax image, host for
-    # numpy -- the same masked semantics either way.
+    # Compute the histogram of the valid entries: on-device (sharded-safe, exact int64 counts) for a
+    # jax image, host for numpy -- the same masked semantics either way.
     if isinstance(image, jax.Array):
         if valid_mask is None:
-            valid_mask = jnp.ones((1,) * image.ndim, dtype=bool)
-        hist, bin_edges = _sharded_histogram(image, valid_mask, num_bins)
-        hist, bin_edges = np.array(hist), np.array(bin_edges)   # tiny (num_bins,) transfers
+            valid_mask = np.ones((1,) * image.ndim, dtype=bool)
+        hist, bin_edges = _sharded_histogram(image, valid_mask, num_bins)   # host numpy results
     elif valid_mask is not None:
         hist, bin_edges = _masked_histogram(image, np.asarray(valid_mask), num_bins, np)
     else:
-        hist, bin_edges = np.histogram(image, bins=num_bins, range=(np.min(image), np.max(image)))
+        # Python-float range endpoints for the same reason as in _masked_histogram (edge consistency
+        # across the numpy and sharded paths).
+        hist, bin_edges = np.histogram(image, bins=num_bins, range=(float(np.min(image)), float(np.max(image))))
 
     # Find the optimal thresholds (half-open class-boundary bin indices) by dynamic programming
     thresholds = _otsu_thresholds_dp(hist, classes - 1)

--- a/mbirjax/preprocess/segmentation.py
+++ b/mbirjax/preprocess/segmentation.py
@@ -56,7 +56,7 @@ def multi_threshold_otsu(image, classes=2, num_bins=1024, valid_mask=None):
         classes (int, optional):
             Number of classes to divide the image into. Must be ≥ 2. Defaults to 2.
         num_bins (int, optional):
-            Number of bins to use when constructing the image histogram. Defaults to 256.
+            Number of bins to use when constructing the image histogram. Defaults to 1024.
         valid_mask (array or None, optional):
             Broadcastable boolean mask, True on the entries to include (applied uniformly for numpy and
             jax inputs).  Used e.g. to exclude the zero-padded entries of a device-form (sharded) volume
@@ -90,145 +90,97 @@ def multi_threshold_otsu(image, classes=2, num_bins=1024, valid_mask=None):
     else:
         hist, bin_edges = np.histogram(image, bins=num_bins, range=(np.min(image), np.max(image)))
 
-    # Find the optimal thresholds using a recursive approach
-    thresholds = _recursive_otsu(hist, classes - 1)
+    # Find the optimal thresholds (half-open class-boundary bin indices) by dynamic programming
+    thresholds = _otsu_thresholds_dp(hist, classes - 1)
 
-    # Convert histogram bin indices to original image values
-    bin_centers = (bin_edges[:-1] + bin_edges[1:]) / 2
-    scaled_thresholds = [bin_centers[t] for t in thresholds]
-    # print(scaled_thresholds)
+    # Convert boundary indices to image values.  bin_edges[t] is the exact cut for boundary t: values
+    # below it fall precisely in bins < t (the lower classes), matching the histogram split.
+    scaled_thresholds = [bin_edges[t] for t in thresholds]
 
-    # import matplotlib.pyplot as plt
-    # plt.bar(bin_edges[:-1], hist, width=np.diff(bin_edges), edgecolor="black", align="edge")
-    # plt.show(block=True)
     return scaled_thresholds
 
 
-def _recursive_otsu(hist, num_thresholds):
+def _otsu_thresholds_dp(hist, num_thresholds):
     """
-    Recursively applies Otsu's method to find the best thresholds for multiple classes.
+    Multi-threshold Otsu via dynamic programming.
 
-    Parameters
-    ----------
-    hist : ndarray
-        Histogram of the image.
-    num_thresholds : int
-        Number of thresholds to find.
+    Otsu's criterion minimizes the total within-class variance: for thresholds t_1 < ... < t_k, class
+    ``c`` spans the bin interval ``[t_c, t_{c+1})`` (with t_0 = 0 and t_{k+1} = num_bins) and the
+    objective is
 
-    Returns
-    -------
-    list
-        List of thresholds that divide the histogram into the specified number of classes.
+        sum over classes of   sum_{i in class} (i - class mean)^2 * hist[i].
+
+    The objective is separable over the classes, so the optimal thresholds solve the classic 1-D
+    segmentation DP
+
+        D[c][b] = min over s < b of  D[c-1][s] + cost(s, b),
+
+    where ``cost(a, b)`` is the within-class term of a single class spanning bins ``[a, b)``.  The cost
+    is O(1) from prefix sums of the histogram's zeroth/first/second moments, each DP stage is one
+    vectorized (B+1)^2 min-reduction, and the thresholds come from an argmin backtrack: O(k B^2)
+    float64 NumPy with no recursion and no per-bin Python loops, exact for every ``num_thresholds``.
+
+    Threshold convention: returned values are half-open class boundaries -- threshold ``t`` means bin
+    ``t`` starts the next class.  The consistent threshold VALUE is therefore the left bin edge
+    ``bin_edges[t]``: values below it fall exactly in bins < t (the lower classes).
+
+    Args:
+        hist (ndarray): Histogram of the image (counts; any nonnegative dtype).
+        num_thresholds (int): Number of thresholds to find (k = classes - 1).
+
+    Returns:
+        list of int: strictly increasing boundary indices in ``[1, len(hist) - 1]``.
     """
-    # Base case: no thresholds needed
     if num_thresholds == 0:
         return []
 
-    # Base case: single threshold needed
-    if num_thresholds == 1:
-        return [_binary_threshold_otsu(hist)]
+    hist = np.asarray(hist, dtype=np.float64)
+    num_bins = len(hist)
+    # Bin coordinates centered at the histogram midpoint: the within-class variance is shift-invariant,
+    # and centering shrinks the moment magnitudes (~4x on the second moment), reducing cancellation in
+    # the prefix-difference arithmetic below.  float64 is required regardless: the raw second moment
+    # reaches ~bin^2 * count ~ 1e15 for a 1e9-voxel volume, far beyond float32/int32.
+    bin_coord = np.arange(num_bins, dtype=np.float64) - (num_bins - 1) / 2.0
 
-    best_thresholds = []
-    best_variance = float('inf')
+    # Moment prefix sums, each with a leading 0 so that P[j] = (sum over bins i < j) and the moment of
+    # any bin interval [a, b) is P[b] - P[a].  m0 = counts, m1 = first moment, m2 = second moment.
+    m0 = np.concatenate(([0.0], np.cumsum(hist)))
+    m1 = np.concatenate(([0.0], np.cumsum(bin_coord * hist)))
+    m2 = np.concatenate(([0.0], np.cumsum(bin_coord * bin_coord * hist)))
 
-    # Iterate through possible thresholds
-    for t in range(1, len(hist) - 1):
-        # Split histogram at the threshold
-        left_hist = hist[:t]
-        right_hist = hist[t:]
+    # Moments of every candidate class interval at once: outer differences, entry [a, b] = P[b] - P[a]
+    # = the moment of bins [a, b).
+    int_m0 = m0[None, :] - m0[:, None]
+    int_m1 = m1[None, :] - m1[:, None]
+    int_m2 = m2[None, :] - m2[:, None]
 
-        # Recursively find thresholds for left and right segments
-        left_thresholds = _recursive_otsu(left_hist, num_thresholds // 2)
-        right_thresholds = _recursive_otsu(right_hist, num_thresholds - len(left_thresholds) - 1)
+    # Within-class cost of the interval [a, b): expanding sum (i - mean)^2 h_i with mean = M1/M0 gives
+    # M2 - M1^2/M0.  Empty (zero-count) intervals cost 0 (an empty class contributes no variance);
+    # structurally invalid entries (a >= b) are +inf so the argmin can never produce non-increasing
+    # boundaries.
+    mean_sq_term = np.divide(int_m1 ** 2, int_m0, out=np.zeros_like(int_m0), where=int_m0 > 0)
+    cost = np.maximum(int_m2 - mean_sq_term, 0.0)      # clip tiny negative rounding residue
+    invalid = ~np.triu(np.ones((num_bins + 1, num_bins + 1), dtype=bool), k=1)   # a >= b
+    cost[invalid] = np.inf
 
-        # Combine thresholds
-        thresholds = left_thresholds + [t] + [x + t for x in right_thresholds]
+    # DP stages: best[b] = minimal cost of covering bins [0, b) with the current number of classes.
+    # Each stage adds one class: total[s, b] = (best cover of [0, s) so far) + (one new class [s, b));
+    # the argmin over s is recorded per b for the backtrack.
+    best = cost[0, :].copy()                           # one class: [0, b)
+    split_of = np.zeros((num_thresholds, num_bins + 1), dtype=np.int64)
+    for stage in range(num_thresholds):
+        total = best[:, None] + cost                   # total[s, b]
+        split_of[stage] = np.argmin(total, axis=0)
+        best = np.min(total, axis=0)
 
-        # Compute the total within-class variance
-        total_variance = _compute_within_class_variance(hist, thresholds)
-
-        # Update the best thresholds if the current variance is lower
-        if total_variance < best_variance:
-            best_variance = total_variance
-            best_thresholds = thresholds
-
-    return best_thresholds
-
-
-def _binary_threshold_otsu(hist):
-    """
-    Finds the best threshold for binary segmentation using Otsu's method.
-
-    Parameters
-    ----------
-    hist : ndarray
-        Histogram of the image.
-
-    Returns
-    -------
-    int
-        Best threshold for binary segmentation.
-    """
-    total = np.sum(hist)
-    current_max, threshold = 0, 0
-    sum_total, sum_foreground, weight_foreground, weight_background = 0, 0, 0, 0
-
-    # Compute the sum of pixel values
-    for i in range(len(hist)):
-        sum_total += i * hist[i]
-
-    # Iterate through possible thresholds
-    for i in range(len(hist)):
-        weight_foreground += hist[i]
-        if weight_foreground == 0:
-            continue
-        weight_background = total - weight_foreground
-        if weight_background == 0:
-            break
-
-        sum_foreground += i * hist[i]
-        mean_foreground = sum_foreground / weight_foreground
-        mean_background = (sum_total - sum_foreground) / weight_background
-
-        # Compute between-class variance
-        between_class_variance = weight_foreground * weight_background * (mean_foreground - mean_background) ** 2
-        if between_class_variance > current_max:
-            current_max = between_class_variance
-            threshold = i
-
-    return threshold
-
-
-def _compute_within_class_variance(hist, thresholds):
-    """
-    Computes the total within-class variance given a set of thresholds.
-
-    Parameters
-    ----------
-    hist : ndarray
-        Histogram of the image.
-    thresholds : list
-        List of thresholds that divide the histogram into multiple classes.
-
-    Returns
-    -------
-    float
-        Total within-class variance.
-    """
-    total_variance = 0
-    thresholds = [0] + thresholds + [len(hist)]
-
-    # Iterate through each segment defined by the thresholds
-    for i in range(len(thresholds) - 1):
-        class_hist = hist[thresholds[i]:thresholds[i+1]]
-        class_prob = np.sum(class_hist)
-        if class_prob == 0:
-            continue
-        class_mean = np.sum(class_hist * np.arange(thresholds[i], thresholds[i+1])) / class_prob
-        class_variance = np.sum(((np.arange(thresholds[i], thresholds[i+1]) - class_mean) ** 2) * class_hist) / class_prob
-        total_variance += class_variance * class_prob
-
-    return total_variance
+    # Backtrack from the full range [0, num_bins): the last stage's argmin at b = num_bins is the last
+    # threshold; each recovered threshold then indexes the previous stage's argmin row.
+    boundaries = []
+    b = num_bins
+    for stage in range(num_thresholds - 1, -1, -1):
+        b = int(split_of[stage][b])
+        boundaries.append(b)
+    return boundaries[::-1]
 
 
 def segment_plastic_metal(recon, num_metal, radial_margin=10, top_margin=10, bottom_margin=10,

--- a/mbirjax/preprocess/segmentation.py
+++ b/mbirjax/preprocess/segmentation.py
@@ -1,9 +1,43 @@
+import functools
 import numpy as np
+import jax
 import jax.numpy as jnp
 import mbirjax.preprocess as mjp
 
 
-def multi_threshold_otsu(image, classes=2, num_bins=1024):
+def _masked_histogram(image, valid_mask, num_bins, xp):
+    """Histogram of the valid entries of ``image``, matching ``histogram(image, num_bins,
+    range=(min, max))`` computed over the valid entries only.
+
+    The range comes from masked min/max, and invalid entries are pushed to a finite sentinel ABOVE the
+    range, which ``histogram``'s range semantics then drop -- so the bin EDGES and counts are exactly
+    those of the valid entries (no post-hoc count correction needed).  ``xp`` is the array module:
+    ``np`` runs eagerly on the host; ``jnp`` runs on-device (see :func:`_sharded_histogram` for the
+    jitted wrapper).  The infinity/one constants are typed to ``image.dtype`` so the ``where`` cannot
+    silently upcast (a float64 scalar would double the full-size temporaries).
+    """
+    inf = xp.asarray(xp.inf, dtype=image.dtype)
+    lo = xp.min(xp.where(valid_mask, image, inf))
+    hi = xp.max(xp.where(valid_mask, image, -inf))
+    sentinel = hi + xp.maximum(xp.abs(hi), xp.asarray(1.0, dtype=image.dtype))  # finite, strictly > hi
+    return xp.histogram(xp.where(valid_mask, image, sentinel), bins=num_bins, range=(lo, hi))
+
+
+@functools.partial(jax.jit, static_argnums=2)   # num_bins sets the output shape -> compile constant
+def _sharded_histogram(image, valid_mask, num_bins=1024):
+    """Jitted :func:`_masked_histogram` for a (possibly view/slice-sharded) jax volume.
+
+    A histogram is sum-decomposable (``hist(x) = sum over shards of hist(x_shard)``, integer counts), so
+    on a sharded array XLA compiles this to per-shard partial histograms + an all-reduce of the tiny
+    ``(num_bins,)`` output -- verified 0 all-gathers.  min/max are likewise exact all-reduces (order
+    insensitive), so the result is bit-identical to the host computation on the valid entries.
+
+    Returns (hist, bin_edges) as device arrays (tiny; callers convert to host).
+    """
+    return _masked_histogram(image, valid_mask, num_bins, jnp)
+
+
+def multi_threshold_otsu(image, classes=2, num_bins=1024, valid_mask=None):
     """
     Segment an image into multiple intensity classes using Otsu's method.
 
@@ -11,13 +45,23 @@ def multi_threshold_otsu(image, classes=2, num_bins=1024):
     number of classes by minimizing the intra-class variance. It returns `classes - 1` thresholds
     that can be used to partition the image intensity range into `classes` distinct segments.
 
+    A NumPy image is histogrammed on the host; a JAX image is histogrammed on its own device(s) --
+    including a sharded volume, whose per-shard partial histograms combine in a cross-device reduction
+    (bit-identical counts; no gather of the volume).  Only the tiny histogram itself comes to the host
+    for the threshold search.
+
     Args:
-        image (np.ndarray):
-            Input image as a NumPy array of floating-point values.
+        image (np.ndarray or jax.Array):
+            Input image of floating-point values.
         classes (int, optional):
             Number of classes to divide the image into. Must be ≥ 2. Defaults to 2.
         num_bins (int, optional):
             Number of bins to use when constructing the image histogram. Defaults to 256.
+        valid_mask (array or None, optional):
+            Broadcastable boolean mask, True on the entries to include (applied uniformly for numpy and
+            jax inputs).  Used e.g. to exclude the zero-padded entries of a device-form (sharded) volume
+            so the histogram range and counts match the unpadded volume exactly.  None includes
+            everything.
 
     Returns:
         list of float:
@@ -34,8 +78,17 @@ def multi_threshold_otsu(image, classes=2, num_bins=1024):
     if num_bins < classes:
         raise ValueError("Number of bins must be at least equal to number of classes")
 
-    # Compute the histogram of the image
-    hist, bin_edges = np.histogram(image, bins=num_bins, range=(np.min(image), np.max(image)))
+    # Compute the histogram of the valid entries: on-device (sharded-safe) for a jax image, host for
+    # numpy -- the same masked semantics either way.
+    if isinstance(image, jax.Array):
+        if valid_mask is None:
+            valid_mask = jnp.ones((1,) * image.ndim, dtype=bool)
+        hist, bin_edges = _sharded_histogram(image, valid_mask, num_bins)
+        hist, bin_edges = np.array(hist), np.array(bin_edges)   # tiny (num_bins,) transfers
+    elif valid_mask is not None:
+        hist, bin_edges = _masked_histogram(image, np.asarray(valid_mask), num_bins, np)
+    else:
+        hist, bin_edges = np.histogram(image, bins=num_bins, range=(np.min(image), np.max(image)))
 
     # Find the optimal thresholds using a recursive approach
     thresholds = _recursive_otsu(hist, classes - 1)
@@ -178,16 +231,26 @@ def _compute_within_class_variance(hist, thresholds):
     return total_variance
 
 
-def segment_plastic_metal(recon, num_metal, radial_margin=10, top_margin=10, bottom_margin=10):
+def segment_plastic_metal(recon, num_metal, radial_margin=10, top_margin=10, bottom_margin=10,
+                          valid_mask=None, num_real_slices=None):
     """
     Segment a reconstruction into plastic and multiple metal masks using multi-threshold Otsu.
 
+    ``recon`` may be a host array, a single-device jax array, or a **sharded** device-form volume; the
+    segmentation runs on whatever devices hold it (the Otsu histogram reduces across shards without
+    gathering the volume).  For a device-form volume whose slice axis is zero-padded, pass
+    ``valid_mask`` / ``num_real_slices`` so the padded slices are excluded from the histogram, the
+    bottom margin lands on the real bottom slices, and the class masks are zero on padding (otherwise a
+    threshold interval spanning 0 would include the padded voxels and bias the scaling factors).
+
     Args:
-        recon (jnp.ndarray): Reconstructed volume array.
+        recon (np.ndarray or jax.Array): Reconstructed volume array (host, single-device, or sharded).
         num_metal (int): Number of metal materials to segment.
         radial_margin (int, optional): Margin in pixels to subtract from the cylindrical mask radius.
         top_margin (int, optional): Number of slices to mask out from the top of the volume.
         bottom_margin (int, optional): Number of slices to mask out from the bottom of the volume.
+        valid_mask (jax array or None, optional): Broadcastable boolean mask, True on real voxels.
+        num_real_slices (int or None, optional): Real slice count (see ``apply_cylindrical_mask``).
 
     Returns:
         Tuple[jnp.ndarray, List[jnp.ndarray], float, List[float]]:
@@ -201,17 +264,24 @@ def segment_plastic_metal(recon, num_metal, radial_margin=10, top_margin=10, bot
 
     # Remove any flash from the boundary of the recon
     recon = mjp.apply_cylindrical_mask(recon, radial_margin=radial_margin, top_margin=top_margin,
-                                       bottom_margin=bottom_margin)
+                                       bottom_margin=bottom_margin, num_real_slices=num_real_slices)
 
-    # Compute thresholds using multi-threshold Otsu
-    thresholds = multi_threshold_otsu(recon, classes=num_metal + 2)
+    # Compute thresholds using multi-threshold Otsu (padded voxels excluded via valid_mask)
+    thresholds = multi_threshold_otsu(recon, classes=num_metal + 2, valid_mask=valid_mask)
 
     # Plastic: lowest class
     plastic_low_threshold = thresholds[0]
     plastic_metal_threshold = thresholds[1]
 
-    # Create masks
-    plastic_mask = jnp.where((recon > plastic_low_threshold) & (recon <= plastic_metal_threshold), 1.0, 0.0)
+    # Masks are 1 inside the class interval AND on a real voxel: padded voxels are exactly 0, so a class
+    # interval spanning 0 would otherwise mark them, biasing compute_scaling_factor's denominator.
+    def class_mask(lower, upper):
+        in_class = (recon > lower) & (recon <= upper)
+        if valid_mask is not None:
+            in_class = in_class & valid_mask
+        return jnp.where(in_class, 1.0, 0.0)
+
+    plastic_mask = class_mask(plastic_low_threshold, plastic_metal_threshold)
     plastic_scale = mjp.compute_scaling_factor(recon, plastic_mask)
 
     # Metal masks and scaling
@@ -220,7 +290,7 @@ def segment_plastic_metal(recon, num_metal, radial_margin=10, top_margin=10, bot
     for i in range(1, num_metal + 1):  # start from index 1
         lower = thresholds[i]
         upper = thresholds[i + 1] if i + 1 < len(thresholds) else jnp.inf
-        metal_mask = jnp.where((recon > lower) & (recon <= upper), 1.0, 0.0)
+        metal_mask = class_mask(lower, upper)
         metal_masks.append(metal_mask)
         metal_scales.append(mjp.compute_scaling_factor(recon, metal_mask))
 

--- a/mbirjax/preprocess/segmentation.py
+++ b/mbirjax/preprocess/segmentation.py
@@ -136,11 +136,14 @@ def _otsu_thresholds_dp(hist, num_thresholds):
 
     hist = np.asarray(hist, dtype=np.float64)
     num_bins = len(hist)
-    # Bin coordinates centered at the histogram midpoint: the within-class variance is shift-invariant,
-    # and centering shrinks the moment magnitudes (~4x on the second moment), reducing cancellation in
-    # the prefix-difference arithmetic below.  float64 is required regardless: the raw second moment
-    # reaches ~bin^2 * count ~ 1e15 for a 1e9-voxel volume, far beyond float32/int32.
-    bin_coord = np.arange(num_bins, dtype=np.float64) - (num_bins - 1) / 2.0
+    # Bin coordinates centered and scaled to [-1, 1].  The within-class variance is shift-invariant,
+    # and a uniform scale multiplies EVERY interval cost by the same factor, so the DP's argmin -- and
+    # hence the returned thresholds -- is unchanged in exact arithmetic.  Centering removes the
+    # mean-offset cancellation in the prefix-difference arithmetic below; scaling keeps the moment
+    # prefix sums O(total count) instead of O(count * bins^2) (~1e15 for a 1e9-voxel volume), so all
+    # magnitudes stay comfortably conditioned in float64.
+    half_span = max((num_bins - 1) / 2.0, 1.0)     # max() guards the degenerate 1-bin histogram
+    bin_coord = (np.arange(num_bins, dtype=np.float64) - (num_bins - 1) / 2.0) / half_span
 
     # Moment prefix sums, each with a leading 0 so that P[j] = (sum over bins i < j) and the moment of
     # any bin interval [a, b) is P[b] - P[a].  m0 = counts, m1 = first moment, m2 = second moment.

--- a/mbirjax/preprocess/segmentation.py
+++ b/mbirjax/preprocess/segmentation.py
@@ -39,17 +39,40 @@ def _masked_min_max(image, valid_mask):
 
 @functools.partial(jax.jit, static_argnums=4)
 def _local_bucketize_histogram(image, valid_mask, lo, hi, num_bins):
-    """Single-device masked histogram by explicit bucketize + scatter-add (see _sharded_histogram).
+    """Histogram of one single-device slab by explicit bucketize + scatter-add (see _sharded_histogram).
 
-    In-range values map to bin ``floor(num_bins * (x - lo) / span)``; ``hi`` itself maps to
-    ``num_bins`` and is clipped into the last bin, matching ``np.histogram``'s closed last edge.
-    Invalid / out-of-range entries get an arbitrary in-range index but contribute 0 via the mask.
-    Counts accumulate in int32 -- exact because callers pass SLABS below 2^31 elements (see
-    ``_HISTOGRAM_SLAB_ELEMENTS``); the exact int64 total is accumulated on the host."""
+    Semantics match ``np.histogram`` over the valid entries with ``range=(lo, hi)``: in-range values
+    map to bin ``floor(num_bins * (x - lo) / span)``, ``hi`` itself lands in the last bin (numpy's
+    closed last edge), and invalid or out-of-range entries are dropped.
+
+    Sizes are bounded by construction: callers pass slabs of at most ``_HISTOGRAM_SLAB_ELEMENTS``
+    elements, so the int32 counts cannot wrap (a bin cannot exceed the slab size < 2^31) and the
+    flattened index below is a short, single-device axis -- the >2^31 flat-index hazards do not apply.
+    The exact int64 total across slabs is accumulated on the host by the caller.
+
+    Args:
+        image (jax array): one slab of the volume, resident on a single device.
+        valid_mask (array): boolean mask, broadcastable against ``image``; True on entries to count.
+        lo, hi (scalars): histogram range, typed to ``image.dtype`` by the caller.
+        num_bins (int): number of bins (static -- it sets the output shape).
+
+    Returns:
+        jax array: (num_bins,) int32 counts, on the slab's device.
+    """
+    # Bin index for every entry: map [lo, hi] linearly onto [0, num_bins], then clip so that x == hi
+    # falls in the last bin.  Out-of-range values also clip into [0, num_bins - 1]; their (arbitrary)
+    # index is harmless because they contribute 0 below.  The tiny floor on span guards lo == hi
+    # (a constant slab).
     span = jnp.maximum(hi - lo, jnp.asarray(jnp.finfo(image.dtype).tiny, dtype=image.dtype))
-    idx = jnp.clip((num_bins * (image - lo) / span).astype(jnp.int32), 0, num_bins - 1)
-    contrib = (valid_mask & (image >= lo) & (image <= hi)).astype(jnp.int32)
-    return jnp.zeros(num_bins, dtype=jnp.int32).at[idx.reshape(-1)].add(contrib.reshape(-1))
+    bin_index = jnp.clip((num_bins * (image - lo) / span).astype(jnp.int32), 0, num_bins - 1)
+
+    # Each entry contributes 1 if it is valid and inside [lo, hi], else 0.
+    in_range = (image >= lo) & (image <= hi)
+    contribution = (valid_mask & in_range).astype(jnp.int32)
+
+    # Scatter-add the contributions into the per-bin counts.
+    counts = jnp.zeros(num_bins, dtype=jnp.int32)
+    return counts.at[bin_index.reshape(-1)].add(contribution.reshape(-1))
 
 
 # Per-slab element budget for the on-device histogram: bounds the bucketize's int32 index/contribution

--- a/mbirjax/preprocess/utilities.py
+++ b/mbirjax/preprocess/utilities.py
@@ -752,10 +752,7 @@ def project_vector_to_vector(u1, u2):
     return u1_proj
 
 
-# NOT jitted: this runs eagerly so it is host-preserving (a NumPy recon stays on the host, a jax recon
-# stays on-device -- see the body).  jit would force a device array and trace the input, shipping the
-# whole volume to one GPU (the export-time OOM on large recons).  It's a one-shot post-recon mask (export
-# + MAR segmentation), not a hot path, so eager costs nothing meaningful.
+# Not jitted, so a numpy recon stays on the host (jit would force the whole volume onto one GPU).
 def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0):
     """
     Applies a cylindrical mask to a 3D reconstruction volume.
@@ -767,9 +764,8 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
     This function is useful for removing `flash` that typically accumulates on the boundaries of an MBIR reconstruction volume.
 
     Note:
-        Operates on the input's array module: a host (NumPy) recon stays on the host (no copy to a
-        device) and a jax recon stays on-device.  So a large host volume is masked without being shipped
-        onto a single device -- which would otherwise OOM for big recons.
+        A numpy recon is masked on the host and a jax recon on-device, so a large host volume is
+        never shipped onto a single device (which would OOM for big recons).
 
     Args:
         recon (np.ndarray or jax.Array): 3D volume with shape (num_rows, num_cols, num_slices).
@@ -787,10 +783,7 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
         >>> masked_vol.shape
         (128, 128, 64)
     """
-    # Operate on the input's OWN array module so a host (NumPy) recon stays on the host and a device/jax
-    # recon stays on-device.  The masks are tiny; the expensive op is the full-volume multiply, which
-    # follows recon's residence.  export_recon_hdf5 passes a host recon, so for large volumes nothing is
-    # shipped back onto a single device (jnp here previously forced the whole volume onto gpu0 -> OOM).
+    # Use recon's own array module so a numpy recon stays on the host and a jax recon stays on-device.
     xp = jnp if isinstance(recon, jax.Array) else np
 
     num_recon_rows, num_recon_cols, num_slices = recon.shape
@@ -805,17 +798,21 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
     dist_sq = (row_coords - row_center) ** 2 + (col_coords - col_center) ** 2
     circular_mask = (dist_sq <= radius ** 2).astype(recon.dtype)
 
-    # Apply cylindrical mask to all slices
+    # Circular mask: this multiply allocates the one new array we return; input is untouched.
     recon = recon * circular_mask[:, :, None]
 
-    # Apply a mask to the top and bottom margins.  Built with NumPy (tiny 1-D) to sidestep jax's
-    # functional index-update; the multiply promotes it to recon's module if needed.
-    slice_mask = np.ones((num_slices,), dtype=recon.dtype)
-    if top_margin > 0:
-        slice_mask[:top_margin] = 0
-    if bottom_margin > 0:
-        slice_mask[-bottom_margin:] = 0
-    recon = recon * slice_mask[None, None, :]
+    # Zero top/bottom margins in place on that new array (no second full-volume copy -> 2x not 3x).
+    # numpy is truly in place; jax is immutable so use .at[].set (on-device, not the big path).
+    if xp is np:
+        if top_margin > 0:
+            recon[:, :, :top_margin] = 0
+        if bottom_margin > 0:
+            recon[:, :, -bottom_margin:] = 0
+    else:
+        if top_margin > 0:
+            recon = recon.at[:, :, :top_margin].set(0)
+        if bottom_margin > 0:
+            recon = recon.at[:, :, -bottom_margin:].set(0)
 
     return recon
 

--- a/mbirjax/preprocess/utilities.py
+++ b/mbirjax/preprocess/utilities.py
@@ -753,7 +753,7 @@ def project_vector_to_vector(u1, u2):
 
 
 # Not jitted, so a numpy recon stays on the host (jit would force the whole volume onto one GPU).
-def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0):
+def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0, num_real_slices=None):
     """
     Applies a cylindrical mask to a 3D reconstruction volume.
 
@@ -772,6 +772,9 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
         radial_margin (int): Margin to subtract from the cylinder radius in pixels.
         top_margin (int): Number of top slices to set to zero along the Z-axis.
         bottom_margin (int): Number of bottom slices to set to zero along the Z-axis.
+        num_real_slices (int or None): Number of REAL slices when ``recon`` is a device-form volume whose
+            slice axis is zero-padded (see the recon placement).  The bottom margin is applied at the end
+            of the real slices, not the padded end.  None (default) means all slices are real.
 
     Returns:
         np.ndarray or jax.Array: Masked 3D volume of the same shape and array module as `recon`.
@@ -803,16 +806,19 @@ def apply_cylindrical_mask(recon, radial_margin=0, top_margin=0, bottom_margin=0
 
     # Zero top/bottom margins in place on that new array (no second full-volume copy -> 2x not 3x).
     # numpy is truly in place; jax is immutable so use .at[].set (on-device, not the big path).
+    # The bottom margin ends at the REAL slice count: on a slice-padded device-form volume, [-b:] would
+    # zero the (already-zero) padding instead of the real bottom slices.
+    num_real_slices = recon.shape[2] if num_real_slices is None else num_real_slices
     if xp is np:
         if top_margin > 0:
             recon[:, :, :top_margin] = 0
         if bottom_margin > 0:
-            recon[:, :, -bottom_margin:] = 0
+            recon[:, :, num_real_slices - bottom_margin:num_real_slices] = 0
     else:
         if top_margin > 0:
             recon = recon.at[:, :, :top_margin].set(0)
         if bottom_margin > 0:
-            recon = recon.at[:, :, -bottom_margin:].set(0)
+            recon = recon.at[:, :, num_real_slices - bottom_margin:num_real_slices].set(0)
 
     return recon
 

--- a/mbirjax/tomography_model.py
+++ b/mbirjax/tomography_model.py
@@ -1,5 +1,6 @@
 import functools
 import io
+import math
 import types
 import warnings
 import inspect
@@ -2820,7 +2821,10 @@ class TomographyModel(ParameterHandler):
         # shapes).  Equals the device arrays' size except when the view axis and/or the
         # detector-row axis is padded for sharding; normalizing by the real count keeps the
         # reported losses independent of the (inert, identically-zero) padding.
-        real_sino_size = int(np.prod(self.get_params('sinogram_shape')))
+        # math.prod (exact Python ints), NOT np.prod: numpy's product accumulates in the platform
+        # default integer -- int32 on Windows/numpy<2 -- and a full-size sinogram (>2^31 elements)
+        # would silently wrap.
+        real_sino_size = math.prod(self.get_params('sinogram_shape'))
         pad_active = (self.sino_placement.is_padded
                       or self._sino_row_padding() is not None)
         loss_num_real = real_sino_size if pad_active else None
@@ -2897,7 +2901,7 @@ class TomographyModel(ParameterHandler):
                     # Evaluate the prior loss on the REAL volume: _gather_recon crops any
                     # padded slices (whose zero values would otherwise add spurious
                     # boundary-difference terms to the loss).  Debug/verbose path only.
-                    real_recon_size = int(np.prod(recon_shape))
+                    real_recon_size = math.prod(recon_shape)   # exact Python ints (see real_sino_size)
                     loss_recon = self._gather_recon(flat_recon).reshape(recon_shape)
                     pm_loss[i] = mj.qggmrf_loss(loss_recon, qggmrf_params)
                     pm_loss[i] /= real_recon_size
@@ -3189,7 +3193,7 @@ class TomographyModel(ParameterHandler):
         return forward_linear, forward_quadratic
 
     @staticmethod
-    @functools.partial(jax.jit, static_argnums=(3,), static_argnames=('normalize',))
+    @functools.partial(jax.jit, static_argnums=(3, 4), static_argnames=('normalize', 'num_real_elements'))
     def get_forward_model_loss(error_sinogram, sigma_y, weights=None, normalize=True,
                                num_real_elements=None):
         """
@@ -3216,23 +3220,27 @@ class TomographyModel(ParameterHandler):
         Returns:
             float loss.
         """
+        # Element counts enter the computation as FLOATS: a Python int operand is converted to int32
+        # by jax (x64 disabled), which overflows for sinograms above 2^31 elements (~2.1e9 -- a
+        # full-size half sino exceeds this).  float conversion carries the same ~1e-7 rounding that
+        # jnp.mean's internal count already had.
         if weights is None:
             weights = 1
             avg_weight = 1
         elif num_real_elements is None:
             avg_weight = jnp.average(weights)
         else:
-            avg_weight = jnp.sum(weights) / num_real_elements
+            avg_weight = jnp.sum(weights) / float(num_real_elements)
         if normalize:
             weighted_sq_sum = jnp.sum(error_sinogram * error_sinogram * weights)
-            denom = error_sinogram.size if num_real_elements is None else num_real_elements
+            denom = float(error_sinogram.size) if num_real_elements is None else float(num_real_elements)
             loss = jnp.sqrt(weighted_sq_sum / (avg_weight * denom)) / sigma_y
         else:
             loss = (1.0 / (2 * sigma_y ** 2)) * jnp.sum((error_sinogram * error_sinogram) * weights)
         return loss
 
     @staticmethod
-    @jax.jit
+    @functools.partial(jax.jit, static_argnames=('num_real_elements',))
     def _vcd_iteration_stats(error_sinogram, flat_recon, sigma_y, weights=None, num_real_elements=None,
                              real_sino_size=None):
         """Per-iteration VCD logging stats in ONE fused, jitted pass.

--- a/mbirjax/tomography_model.py
+++ b/mbirjax/tomography_model.py
@@ -1,3 +1,4 @@
+import functools
 import io
 import types
 import warnings
@@ -54,8 +55,14 @@ if jax.config.jax_compilation_cache_dir is None:
     # WE configured the cache -- never override a user's explicit cache configuration.
     if hasattr(jax.config, "jax_persistent_cache_enable_xla_caches"):
         jax.config.update("jax_persistent_cache_enable_xla_caches", "none")
-# Set the GPU memory fraction for JAX
-os.environ['XLA_PYTHON_CLIENT_MEM_FRACTION'] = '0.98'
+# Set the GPU memory fraction for JAX -- the share of each GPU that XLA's BFC pool may reserve.
+# 0.94 rather than 0.98: everything that allocates OUTSIDE the pool (cuSolver/cuDNN workspaces,
+# NCCL/collective vmm buffers for cross-device reductions on sharded arrays) has to fit in the
+# remainder, and the pool RETAINS its high-water mark for the life of the process -- at 0.98 those
+# out-of-pool allocations starved (CUDA_ERROR_OUT_OF_MEMORY from the vmm allocator, cuSolver handle
+# failures) even with the pool mostly idle.  See .claude/lessons.md "Out-of-pool GPU allocations".
+# setdefault (not a hard set) so users can tune per-run via the environment before importing mbirjax.
+os.environ.setdefault('XLA_PYTHON_CLIENT_MEM_FRACTION', '0.94')
 
 recon_param_names = ['num_iterations', 'granularity', 'partition_sequence', 'fm_rmse', 'prior_loss',
                      'regularization_params', 'stop_threshold_change_pct', 'alpha_values']
@@ -2869,13 +2876,14 @@ class TomographyModel(ParameterHandler):
                                                                                                  error_sinogram,
                                                                                                  partition)
 
-            # Compute the stats and display as desired
-            fm_rmse[i] = self.get_forward_model_loss(error_sinogram, sigma_y, weights,
-                                                     num_real_elements=loss_num_real)
-            nmae_update[i] = ell1_for_partition / jnp.sum(jnp.abs(flat_recon))
-            # real_sino_size == error_sinogram.size except under view padding, where the
-            # padded entries are identically zero and must not dilute the RMSE.
-            es_rmse = jnp.linalg.norm(error_sinogram) / jnp.sqrt(float(real_sino_size))
+            # Compute the stats and display as desired -- one fused pass over the error sinogram
+            # (see _vcd_iteration_stats).  real_sino_size == error_sinogram.size except under view
+            # padding, where the padded entries are identically zero and must not dilute the RMSE.
+            fm_loss_i, recon_l1, es_rmse = self._vcd_iteration_stats(
+                error_sinogram, flat_recon, sigma_y, weights,
+                num_real_elements=loss_num_real, real_sino_size=float(real_sino_size))
+            fm_rmse[i] = fm_loss_i
+            nmae_update[i] = ell1_for_partition / recon_l1
             alpha_values[i] = alpha
 
             if verbose >= 1:
@@ -3181,11 +3189,18 @@ class TomographyModel(ParameterHandler):
         return forward_linear, forward_quadratic
 
     @staticmethod
+    @functools.partial(jax.jit, static_argnums=(3,), static_argnames=('normalize',))
     def get_forward_model_loss(error_sinogram, sigma_y, weights=None, normalize=True,
                                num_real_elements=None):
         """
         Calculate the loss function for the forward model from the error_sinogram and weights.
         The error sinogram should be error_sinogram = measured_sinogram - forward_proj(recon)
+
+        This is called once per VCD iteration on the full (possibly sharded) error sinogram, so it is
+        jitted: XLA fuses the elementwise products into the reductions, so no sinogram-sized
+        temporaries are materialized (eagerly, ``e*e``, ``weights/avg`` and their product each
+        allocated a full sinogram per call).  Scalar factors (``avg_weight``, the element count,
+        ``sigma_y``) divide the reduced SUM rather than the full-size array -- algebraically identical.
 
         Args:
             error_sinogram (jax array): 3D error sinogram with shape (num_views, num_det_rows, num_det_channels).
@@ -3209,14 +3224,33 @@ class TomographyModel(ParameterHandler):
         else:
             avg_weight = jnp.sum(weights) / num_real_elements
         if normalize:
-            weighted_sq = (error_sinogram * error_sinogram) * (weights / avg_weight)
-            if num_real_elements is None:
-                loss = jnp.sqrt((1.0 / (sigma_y ** 2)) * jnp.mean(weighted_sq))
-            else:
-                loss = jnp.sqrt((1.0 / (sigma_y ** 2)) * (jnp.sum(weighted_sq) / num_real_elements))
+            weighted_sq_sum = jnp.sum(error_sinogram * error_sinogram * weights)
+            denom = error_sinogram.size if num_real_elements is None else num_real_elements
+            loss = jnp.sqrt(weighted_sq_sum / (avg_weight * denom)) / sigma_y
         else:
             loss = (1.0 / (2 * sigma_y ** 2)) * jnp.sum((error_sinogram * error_sinogram) * weights)
         return loss
+
+    @staticmethod
+    @jax.jit
+    def _vcd_iteration_stats(error_sinogram, flat_recon, sigma_y, weights=None, num_real_elements=None,
+                             real_sino_size=None):
+        """Per-iteration VCD logging stats in ONE fused, jitted pass.
+
+        Returns ``(forward_model_loss, recon_l1, error_sino_rmse)`` as device scalars.  Eagerly, the
+        loss, the recon L1, and ``jnp.linalg.norm(error_sinogram)`` each materialized full-size
+        temporaries and -- on a SHARDED error sinogram -- each separate eager op also carried its own
+        cross-device reduction with its own collective buffers.  One jitted function means one
+        executable, one set of collective allocations, and no full-size temporaries.
+
+        ``real_sino_size`` is the REAL element count for the error-sino RMSE (see the caller: padded
+        entries are identically zero and must not dilute the RMSE).
+        """
+        fm_loss = TomographyModel.get_forward_model_loss(error_sinogram, sigma_y, weights,
+                                                         num_real_elements=num_real_elements)
+        recon_l1 = jnp.sum(jnp.abs(flat_recon))
+        es_rmse = jnp.sqrt(jnp.sum(error_sinogram * error_sinogram) / real_sino_size)
+        return fm_loss, recon_l1, es_rmse
 
     def prox_map(self, prox_input, sinogram, sigma_prox=None, weights=None, init_recon=None, do_initialization=True, stop_threshold_change_pct=0.2,
                  max_iterations=3, first_iteration=0, logfile_path='~/.mbirjax/logs/prox.log', print_logs=True, output_sharded=False):

--- a/mbirjax/tomography_model.py
+++ b/mbirjax/tomography_model.py
@@ -128,7 +128,13 @@ class TomographyModel(ParameterHandler):
         self._qggmrf_interface_masks_cache = None
 
         # The following may be adjusted based on memory in set_devices()
-        self.view_batch_size_for_vmap = 512
+        # 128, not 512: sparse_forward_project's transient scales with view_batch (several coexisting
+        # [view_batch x pixel_batch x det_rows] buffers), and at 1024^3 the old 512 pushed the peak past a
+        # single-GPU pool (~18.8 GiB just for that intermediate -> OOM).  128 cuts it ~4x for a small
+        # (~2%) time cost since the projection is compute-bound.  TODO revisit: scale this with recon size
+        # (large recons want it smaller; small recons are unaffected) and pick a DIVISOR of the per-view-
+        # shard view count so there is no ragged tail batch.
+        self.view_batch_size_for_vmap = 128
         self.pixel_batch_size_for_vmap = 2048
         self.transfer_pixel_batch_size = 100 * self.pixel_batch_size_for_vmap
         self.set_devices()
@@ -3091,6 +3097,17 @@ class TomographyModel(ParameterHandler):
             prior_overrelaxation_factor = 1.0
             prior_quadratic_approx = ((1 / prior_overrelaxation_factor) *
                                       jnp.sum(prior_hess * delta_recon_at_indices ** 2))
+
+            # Free the (now-dead) gradient/Hessian buffers BEFORE the memory-heavy forward projection.
+            # forward_grad/forward_hess were last read by delta_recon_at_indices; prior_grad/prior_hess by
+            # prior_linear/prior_quadratic_approx just above.  In eager mode a queued op pins its inputs, so
+            # blocking on those two scalars (which transitively force delta_recon_at_indices, hence the
+            # forward_* reads) guarantees all four are consumed; the del then releases them -- ~4 subset-
+            # sized arrays (~11.6 GB at the coarse 1024^3 subset) -- so sparse_forward_project's ~5x-volume
+            # transient has room.  Compute-free on a compute-bound GPU: the host was running ahead anyway
+            # and the projection depends on delta_recon_at_indices regardless.  (A no-op if ever jitted.)
+            jax.block_until_ready((prior_linear, prior_quadratic_approx))
+            del forward_grad, prior_grad, forward_hess, prior_hess
 
             # Compute update direction in sinogram domain
             delta_sinogram = sparse_forward_project(delta_recon_at_indices, pixel_indices)

--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -130,9 +130,16 @@ def save_data_hdf5(file_path, array, array_name='array', attributes_dict=None):
 
     # Open HDF5 file for writing
     with h5py.File(file_path, 'w') as f:
-        # Save reconstruction array
-        arr = np.array(array)
-        volume_data = f.create_dataset(array_name, data=arr)
+        # Write slab-by-slab along axis 0 so a large or strided (e.g. transposed) array is never
+        # copied to a full contiguous buffer at once -- only one slab is materialized.
+        volume_data = f.create_dataset(array_name, shape=array.shape, dtype=array.dtype)
+        if array.ndim == 0:
+            volume_data[...] = np.asarray(array)
+        else:
+            row_bytes = array.dtype.itemsize * int(np.prod(array.shape[1:], dtype=np.int64))
+            slab = max(1, (1 << 30) // max(row_bytes, 1))   # ~1 GiB per write
+            for i in range(0, array.shape[0], slab):
+                volume_data[i:i + slab] = np.ascontiguousarray(array[i:i + slab])
 
         # Save reconstruction parameters as attributes
         if isinstance(attributes_dict, dict):

--- a/mbirjax/utilities.py
+++ b/mbirjax/utilities.py
@@ -96,6 +96,28 @@ def save_volume_as_gif(volume, filename, vmin=0, vmax=1):
     imageio.mimsave(filename, images, fps=5)  # 5 frames per second
 
 
+def _write_hdf5_streaming(file_path, array_name, out_shape, dtype, produce_slab, attributes_dict=None):
+    """Create an HDF5 dataset of out_shape/dtype and fill it slab-by-slab along axis 0.
+
+    produce_slab(i0, i1) returns the contiguous slab written to dset[i0:i1].  Only one slab is
+    held at a time, so a large or strided source is never fully copied.
+    """
+    mj.makedirs(file_path)
+    with h5py.File(file_path, 'w') as f:
+        dset = f.create_dataset(array_name, shape=out_shape, dtype=dtype)
+        if len(out_shape) == 0:
+            dset[...] = produce_slab(0, 0)
+        else:
+            row_bytes = np.dtype(dtype).itemsize * int(np.prod(out_shape[1:], dtype=np.int64))
+            slab = max(1, (1 << 30) // max(row_bytes, 1))   # ~1 GiB per write
+            for i in range(0, out_shape[0], slab):
+                dset[i:i + slab] = produce_slab(i, min(i + slab, out_shape[0]))
+        if isinstance(attributes_dict, dict):
+            attributes_dict = mj.TomographyModel.convert_subdicts_to_strings(attributes_dict)
+            for key, value in attributes_dict.items():
+                dset.attrs[key] = value
+
+
 def save_data_hdf5(file_path, array, array_name='array', attributes_dict=None):
     """
     Save a NumPy or JAX array to an HDF5 file, optionally including metadata as attributes.
@@ -125,28 +147,11 @@ def save_data_hdf5(file_path, array, array_name='array', attributes_dict=None):
         >>> file_path = './output/test_part_038.yaml'
         >>> mj.save_data_hdf5(file_path, recon, recon_info)
     """
-    # Ensure output directory exists
-    mj.makedirs(file_path)
+    # Stream the array to disk slab-by-slab (no full contiguous copy, even for a strided view).
+    def produce_slab(i0, i1):
+        return np.asarray(array) if array.ndim == 0 else np.ascontiguousarray(array[i0:i1])
 
-    # Open HDF5 file for writing
-    with h5py.File(file_path, 'w') as f:
-        # Write slab-by-slab along axis 0 so a large or strided (e.g. transposed) array is never
-        # copied to a full contiguous buffer at once -- only one slab is materialized.
-        volume_data = f.create_dataset(array_name, shape=array.shape, dtype=array.dtype)
-        if array.ndim == 0:
-            volume_data[...] = np.asarray(array)
-        else:
-            row_bytes = array.dtype.itemsize * int(np.prod(array.shape[1:], dtype=np.int64))
-            slab = max(1, (1 << 30) // max(row_bytes, 1))   # ~1 GiB per write
-            for i in range(0, array.shape[0], slab):
-                volume_data[i:i + slab] = np.ascontiguousarray(array[i:i + slab])
-
-        # Save reconstruction parameters as attributes
-        if isinstance(attributes_dict, dict):
-            # Convert subdicts to strings
-            attributes_dict = mj.TomographyModel.convert_subdicts_to_strings(attributes_dict)
-            for key, value in attributes_dict.items():
-                volume_data.attrs[key] = value
+    _write_hdf5_streaming(file_path, array_name, array.shape, array.dtype, produce_slab, attributes_dict)
 
 
 def display_translation_vectors(translation_vectors, recon_shape):
@@ -582,17 +587,28 @@ def export_recon_hdf5(file_path, recon, recon_dict=None, remove_flash=False, rad
         >>> export_recon_hdf5("output/recon_volume.h5", recon, recon_dict={"scan_id": "sample1"})
     """
 
-    # This code is designed to work with either numpy or jax arrays or sharded jax arrays
-    # It does this by first moving the input array to the host (NumPy),
-    # and then performing the operations using numpy before writing to disk.
+    # Move the input to the host (NumPy) first so numpy/jax/sharded all collapse to one host case.
     recon = jax.device_get(recon)
 
-    if remove_flash:
-        recon = mj.preprocess.apply_cylindrical_mask(recon, radial_margin, top_margin, bottom_margin)
+    if not remove_flash:
+        # Transposed view; save_data_hdf5 streams it slab-by-slab, so no full copy is made.
+        save_data_hdf5(file_path, np.transpose(recon, (2, 1, 0)), 'recon', recon_dict)
+        return
 
-    recon = np.transpose(recon, (2, 1, 0))   # host view, no copy
+    # remove_flash: mask + transpose + write one slab at a time, so no full masked volume is built.
+    # Slabbing along the slice axis keeps full (rows, cols), so apply_cylindrical_mask gives the
+    # identical circular mask per slab; we just map the global top/bottom margins to each slab.
+    num_rows, num_cols, num_slices = recon.shape
 
-    save_data_hdf5(file_path, recon, 'recon', recon_dict)
+    def produce_slab(s0, s1):
+        ds = s1 - s0
+        local_top = min(max(top_margin - s0, 0), ds)                       # global top slices in this slab
+        local_bottom = min(max(s1 - (num_slices - bottom_margin), 0), ds)  # global bottom slices in this slab
+        block = mj.preprocess.apply_cylindrical_mask(recon[:, :, s0:s1], radial_margin, local_top, local_bottom)
+        return np.ascontiguousarray(np.transpose(block, (2, 1, 0)))        # (ds, C, R)
+
+    _write_hdf5_streaming(file_path, 'recon', (num_slices, num_cols, num_rows), recon.dtype,
+                          produce_slab, recon_dict)
 
 
 def import_recon_hdf5(file_path):

--- a/mbirjax/vcls.py
+++ b/mbirjax/vcls.py
@@ -6,8 +6,24 @@ import warnings
 import numpy as np
 import matplotlib.pyplot as plt
 import mbirjax as mj
+import jax
 import jax.numpy as jnp
 import tqdm
+
+
+@jax.jit
+def _normalize_by_norm(x, eps):
+    """``x / (||x|| + eps)``, jitted so the norm's square/sum and the divide fuse into one executable
+    (eagerly, each op dispatches separately and materializes its own full-size temporary)."""
+    return x / (jnp.linalg.norm(x) + eps)
+
+
+@jax.jit
+def _normalize_and_project(x, ref, eps):
+    """Normalized ``x`` and its full contraction with ``ref``, in one fused executable -- used once
+    per view in :func:`compute_view_basis_functions` (see :func:`_normalize_by_norm`)."""
+    x_normalized = x / (jnp.linalg.norm(x) + eps)
+    return x_normalized, jnp.tensordot(x_normalized, ref)
 
 
 def _make_single_view_sibling(ct_model):
@@ -214,9 +230,7 @@ def compute_view_basis_functions(ct_model, ref_object, r_1, data_store_dir, seed
     mask = mj.get_2d_ror_mask(ref_object[:, :, 0].shape)
     sparse_indices, row_col_indices = get_2d_subsampling_indices(mask, r_1, seed=seed)
     ref_object_flat = ref_object.reshape(ref_object.shape[0] * ref_object.shape[1], ref_object.shape[2])
-    sparse_ref_object = jnp.asarray(ref_object_flat[sparse_indices, :])
-    norm_sparse_ref = jnp.linalg.norm(sparse_ref_object)
-    sparse_ref_object /= (norm_sparse_ref + eps)
+    sparse_ref_object = _normalize_by_norm(jnp.asarray(ref_object_flat[sparse_indices, :]), eps)
 
     # Get number of views and angles
     num_views = ct_model.get_params('sinogram_shape')[0]
@@ -241,14 +255,15 @@ def compute_view_basis_functions(ct_model, ref_object, r_1, data_store_dir, seed
         single_view_model.set_view_parameters(jnp.asarray(full_view_params[i:i + 1]))
         recon_i = single_view_model.sparse_back_project(view_sino, sparse_indices)
 
-        norm_i = jnp.linalg.norm(recon_i) + eps
-        recon_i /= (norm_i + eps)
+        # One fused normalize + contraction per view.  (This also collapses a historical double-eps:
+        # the eager code added eps to the norm and again in the divide -- a ~1e-12 difference.)
+        recon_i, gamma_i = _normalize_and_project(recon_i, sparse_ref_object, eps)
 
         # Save view basis function
         with open(os.path.join(data_store_dir, f'view_basis_function{i}.npy'), 'wb') as f:
             np.save(f, recon_i)
 
-        gamma[i, 0] = jnp.tensordot(recon_i, sparse_ref_object)
+        gamma[i, 0] = gamma_i
     return gamma
 
 

--- a/tests/sharding/test_mar.py
+++ b/tests/sharding/test_mar.py
@@ -1,0 +1,171 @@
+"""
+Sharded MAR tests (``preprocess/mar.py``): device-count consistency of the beam-hardening
+correction (with view AND slice padding), the constraint-update path, the empty-class guards, the
+per-axis argmin, and the ``recon_plastic_metal`` output contract.
+
+These exist because two real bugs lived in branches no test exercised: a flat pixel index applied
+to the 3-D view-sharded sinogram silently grabbed a whole VIEW (only the residual-constraint branch
+hit it -- forced here via ``tolerance``), and ``jnp.argmin``'s int32 index labels WRAP on >2^31
+arrays (only full-size data hits it; these tests pin the small-scale behavior the per-axis
+``_argmin_3d`` rewrite must preserve).
+"""
+import unittest
+import numpy as np
+import jax.numpy as jnp
+import mbirjax as mj
+import mbirjax.preprocess as mjp
+from mbirjax.preprocess.mar import (_argmin_3d, _est_plastic_metal_sinos_from_recon,
+                                    _estimate_BH_model_params, _generate_metal_exponent_list)
+from conftest import preferred_devices, assert_sharded_allclose
+
+# 31 views and 25 detector rows -> 25 recon slices: BOTH the view and slice axes pad at 3 devices,
+# so the device-form (padded) code paths are exercised, not just the dividing case.
+SINO_SHAPE = (31, 25, 28)
+
+
+def _make_model(devices=None):
+    angles = np.linspace(0, np.pi, SINO_SHAPE[0], endpoint=False)
+    model = mj.ParallelBeamModel(SINO_SHAPE, angles)
+    if devices is not None:
+        model.configure_devices(devices)
+    return model
+
+
+def _make_phantom(model, with_metal=True):
+    """Plastic cylinder (0.3 + small noise) with an optional dense metal blob (3.0)."""
+    recon_shape = model.get_params('recon_shape')
+    num_rows, num_cols, _ = recon_shape
+    rng = np.random.default_rng(0)
+    recon = np.zeros(recon_shape, np.float32)
+    yy, xx = np.mgrid[0:num_rows, 0:num_cols]
+    cylinder = ((yy - num_rows / 2) ** 2 + (xx - num_cols / 2) ** 2) < (min(num_rows, num_cols) / 2 - 3) ** 2
+    recon[cylinder] = 0.3
+    recon += (rng.normal(0, 0.01, recon_shape) * cylinder[:, :, None]).astype(np.float32)
+    if with_metal:
+        recon[num_rows // 2 - 2:num_rows // 2 + 2, num_cols // 2 - 2:num_cols // 2 + 2, :] = 3.0
+    return recon
+
+
+def _h_exponent_list(num_metal, order):
+    metal_exp = _generate_metal_exponent_list(num_metal, order)
+    cross_exp = _generate_metal_exponent_list(num_metal, order - 1)
+    return ([(1,) + (0,) * num_metal] + [(1, *t) for t in cross_exp] + [(0, *t) for t in metal_exp],
+            len(cross_exp))
+
+
+class TestArgmin3d(unittest.TestCase):
+
+    def test_matches_flat_argmin_including_ties(self):
+        """_argmin_3d == unraveled flat argmin (index AND value), including tie cases: a duplicate
+        minimum in a later view, a duplicate later in the same view, and an all-equal plateau
+        (row-major first-occurrence tie-breaking)."""
+        rng = np.random.default_rng(0)
+        for trial in range(60):
+            x = rng.normal(size=(7, 6, 5)).astype(np.float32)
+            if trial % 4 == 1:
+                pos = np.unravel_index(np.argmin(x), x.shape)
+                x[(pos[0] + 2) % 7, pos[1], pos[2]] = x[pos]
+            elif trial % 4 == 2:
+                pos = np.unravel_index(np.argmin(x), x.shape)
+                x[pos[0], (pos[1] + 1) % 6, (pos[2] + 2) % 5] = x[pos]
+            elif trial % 4 == 3:
+                x[:] = 1.0
+            idx, val = _argmin_3d(jnp.asarray(x))
+            flat = int(np.argmin(x))
+            self.assertEqual(np.ravel_multi_index(idx, x.shape), flat)
+            self.assertEqual(float(val), float(x.reshape(-1)[flat]))
+
+
+class TestCorrectSinoPlasticMetal(unittest.TestCase):
+
+    def test_multi_device_consistency(self):
+        """The corrected sinogram at 3 devices (padded views AND slices) matches the 1-device
+        result.  Tolerance 1e-3, looser than the projector 1e-5: the BH fit's constraint SELECTION
+        (argmin pixels) is discretely sensitive to reduce-order float noise, and theta differences
+        then spread across the sinogram (measured rel_max ~2e-4 on this phantom)."""
+        single = preferred_devices(1)
+        multi = preferred_devices(3)
+        if single is None or multi is None:
+            self.skipTest("need >= 3 devices")
+        model1 = _make_model(single)
+        phantom = _make_phantom(model1)
+        measured = np.array(model1.forward_project(phantom))
+
+        ref = np.asarray(mjp.mar.correct_sino_plastic_metal(model1, measured, phantom, num_metal=1))
+        model3 = _make_model(multi)
+        out = np.asarray(mjp.mar.correct_sino_plastic_metal(model3, measured, phantom, num_metal=1))
+
+        self.assertTrue(np.isfinite(ref).all() and np.isfinite(out).all())
+        self.assertEqual(out.shape, measured.shape)      # padding cropped on return
+        assert_sharded_allclose(out, ref, msg="corrected sinogram diverged across device counts",
+                                tol=1e-3)
+
+    def test_constraint_update_path(self):
+        """Force BOTH constraint branches every iteration (tolerance=1e10) on a padded sharded
+        model: exercises _get_row_H, the u_m pixel read, the A/u stacking, and the OSQP solve --
+        the path where the flat-index bugs lived."""
+        multi = preferred_devices(3)
+        if multi is None:
+            self.skipTest("need >= 3 devices")
+        model = _make_model(multi)
+        phantom = _make_phantom(model)
+        measured = model.prepare_sino_for_devices(np.array(model.forward_project(phantom)))
+
+        num_metal = 1
+        h_exponents, num_cross = _h_exponent_list(num_metal, order=3)
+        plastic, metals = _est_plastic_metal_sinos_from_recon(phantom, num_metal, model)
+        plastic = plastic / jnp.max(jnp.abs(plastic))
+        metals = [m / jnp.max(jnp.abs(m)) for m in metals]
+        view_mask = model.sino_placement.real_mask(measured.ndim)
+
+        theta = _estimate_BH_model_params(plastic, metals, measured, h_exponents, num_cross,
+                                          alpha=1, beta=0.002, num_constraint_update_iter=3,
+                                          tolerance=1e10, view_mask=view_mask)
+        theta = np.asarray(theta)
+        self.assertEqual(theta.shape, (len(h_exponents),))
+        self.assertTrue(np.isfinite(theta).all())
+
+    def test_empty_plastic_raises(self):
+        """A recon whose Otsu plastic class is empty (two-valued: background 0 and metal 3.0 only)
+        must fail fast with the actionable ValueError, not propagate NaNs from a 0/0 normalize."""
+        single = preferred_devices(1)
+        if single is None:
+            self.skipTest("need >= 1 device")
+        model = _make_model(single)
+        phantom = _make_phantom(model, with_metal=True)
+        phantom[(phantom > 0) & (phantom < 1.0)] = 0.0       # remove the plastic class entirely
+        measured = np.array(model.forward_project(phantom))
+        with self.assertRaisesRegex(ValueError, "plastic"):
+            mjp.mar.correct_sino_plastic_metal(model, measured, phantom, num_metal=1)
+
+
+class TestReconPlasticMetalContract(unittest.TestCase):
+
+    def test_output_sharded_contract(self):
+        """recon_plastic_metal returns a host ndarray by default and the sharded device form with
+        output_sharded=True, and the two agree.  The VCD partition RNG is seeded before each call
+        so the two runs draw identical partitions (comparing unseeded runs compares noise)."""
+        multi = preferred_devices(3)
+        if multi is None:
+            self.skipTest("need >= 3 devices")
+        model = _make_model(multi)
+        phantom = _make_phantom(model)
+        measured = np.array(model.forward_project(phantom))
+
+        np.random.seed(7)
+        recon_host = mjp.recon_plastic_metal(model, measured, None, num_BH_iterations=1,
+                                             num_metal=1, stop_threshold_change_pct=5.0)
+        np.random.seed(7)
+        recon_dev = mjp.recon_plastic_metal(model, measured, None, num_BH_iterations=1,
+                                            num_metal=1, stop_threshold_change_pct=5.0,
+                                            output_sharded=True)
+
+        self.assertIsInstance(recon_host, np.ndarray)
+        self.assertEqual(recon_host.shape, tuple(model.get_params('recon_shape')))
+        self.assertNotIsInstance(recon_dev, np.ndarray)      # device form
+        assert_sharded_allclose(np.asarray(model._gather_recon(recon_dev)), recon_host,
+                                msg="output_sharded form diverged from the host default", tol=1e-4)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Shard the MAR/preprocessing path and cut memory for large multi-GPU reconstructions

Extends multi-GPU sharding to the metal-artifact-reduction (MAR) preprocessing path, which previously ran on a single device — so MAR now scales with the recon instead of bottlenecking on one GPU.
Substantially lowers peak GPU memory across the reconstruction, letting materially larger volumes fit on multi-GPU hardware without running out of memory.
Makes the image segmentation MAR relies on sharded, memory-bounded, and faster, so it scales to full-size volumes.
Adds robustness for very large problems — large-integer handling, empty-region guards, and lower-memory reconstruction file export.
No change to reconstruction results or the public API; behavior is device-count-independent as before.