### PR TITLE
Artifacts

### DIFF
--- a/demo/demo_10_artifacts.py
+++ b/demo/demo_10_artifacts.py
@@ -58,8 +58,8 @@ import mbirjax as mj
 import mbirjax.preprocess as mjp
 
 # ----------------------------- user choice --------------------------------------
-regime = ('beam_hardening_streaks', 'medium')  # tags: see the docstring above
-custom = {}          # optional overrides, e.g. {'recon': {'sharpness': 2.0}}
+regime = ('cylinder_streaks', 'medium')  # tags: see the docstring above
+custom = {}         # optional overrides, e.g. {'recon': {'sharpness': 2.0}}
 # --------------------------------------------------------------------------------
 
 
@@ -211,10 +211,11 @@ def main():
     ct_model.set_params(sharpness=r['sharpness'], snr_db=r['snr_db'])
     print(f"Reconstruction grid {ct_model.get_params('recon_shape')}; "
           "standard reconstruction (linear model)...")
-    recon_std, _ = ct_model.recon(sino, weights=weights,
+    recon_direct, _ = ct_model.recon(sino, weights=weights, max_iterations=0)
+    recon_std, _ = ct_model.recon(sino, weights=weights, init_recon=recon_direct,
                                   max_iterations=r['max_iterations'])
-    recons = [ground_truth, np.asarray(recon_std)]
-    labels = ['ground truth', 'standard recon']
+    recons = [ground_truth, np.asarray(recon_direct), np.asarray(recon_std)]
+    labels = ['ground truth', 'direct recon', 'standard recon']
 
     m = p['mar']
     if m['use_mar']:

--- a/demo/demo_10_artifacts.py
+++ b/demo/demo_10_artifacts.py
@@ -1,0 +1,400 @@
+# -*- coding: utf-8 -*-
+"""**MBIRJAX: Artifacts demo — unmodeled physics, what it does, and which knob fixes it**
+
+This script simulates a CT scan of a plastic slab holding a layer of metal
+balls, with selectable unmodeled physics -- lateral or axial field-of-view
+truncation, beam hardening (a polychromatic source), or combinations -- then
+reconstructs with the standard linear model and displays ground truth and
+reconstructions side by side.  Each regime prints what to look for and which
+parameter remedies it (lateral/axial padding, the plastic-metal MAR
+correction :func:`mbirjax.preprocess.recon_plastic_metal`).
+
+Pick a regime by name below.  Tags compose left to right (later tags win),
+and any individual value can be overridden through ``custom``:
+
+    regime = ('beam_hardening_streaks', 'small', 'sparse')
+    regime = ('cylinder_streaks', 'medium')
+    regime = ('bga_like', 'large')
+    custom = {'recon': {'lateral_pad_scale': 1.5}}   # turn a remedy on
+
+Artifact tags (choose one or more; they compose):
+    cylinder_streaks       object wider than the field of view + aggressive
+                           regularization: fine vertical z-coherent striping.
+    beam_hardening_cupping one large metal ball, polychromatic source: the
+                           classic darkened-center / cupped profile.
+    beam_hardening_streaks a grid of small metal balls: dark bands and streaks
+                           between the balls.  ('beam_hardening' = alias.)
+    lateral_fov            object wider than the field of view at default
+                           settings: the bright boundary ring + interior bias.
+    axial_fov              object taller than the axial coverage: flash and
+                           ringing at the top and bottom slices.
+    bga_like               lateral_fov + hardening + a dense grid: the
+                           uncorrected real-scan situation.
+
+Size tags (choose one):     small (64), medium (128, default), large (256).
+Density tags (optional):    sparse (few big balls), dense (many small balls).
+
+Every parameter is documented inline in ``BASE_PARAMS`` at the bottom of this
+file; the regime tags are small overlays on it (``TAGS``), so what each tag
+changes is directly readable there.
+
+Notes on reading the beam-hardening results:
+  - The MAR correction reinserts the metal as reconstructed, so it does not
+    (and does not try to) restore the true metal values; the whole-volume
+    NRMSE is metal-dominated.  The plastic-region NRMSE and the slice viewer
+    are the meaningful comparisons.
+  - The plastic/metal split is identified by the rays that miss the metal:
+    dense ball grids (few metal-free rays) make the fit harder, and extra
+    correction-reconstruction alternations can amplify segmentation errors on
+    synthetic data -- both are interesting regimes to explore.
+
+No command line arguments: edit the two lines below and run.
+"""
+
+import pprint
+
+import numpy as np
+import mbirjax as mj
+import mbirjax.preprocess as mjp
+
+# ----------------------------- user choice --------------------------------------
+regime = ('beam_hardening_streaks', 'medium')  # tags: see the docstring above
+custom = {}          # optional overrides, e.g. {'recon': {'sharpness': 2.0}}
+# --------------------------------------------------------------------------------
+
+
+# ---- A compact polychromatic model: Kramers spectrum + two-basis attenuation ----
+def klein_nishina(e_kev):
+    k = np.asarray(e_kev, dtype=np.float64) / 511.0
+    return ((1 + k) / k ** 2 * (2 * (1 + k) / (1 + 2 * k) - np.log(1 + 2 * k) / k)
+            + np.log(1 + 2 * k) / (2 * k) - (1 + 3 * k) / (1 + 2 * k) ** 2)
+
+
+def make_spectrum(kvp, filtration_mm_al, n_bins=24, e_min=20.0, e_ref=60.0):
+    edges = np.linspace(e_min, kvp, n_bins + 1)
+    e = 0.5 * (edges[:-1] + edges[1:])
+    mu_al = 0.075 * (0.35 * (e / e_ref) ** -3
+                     + 0.65 * klein_nishina(e) / klein_nishina(e_ref))
+    s = np.maximum(kvp - e, 0.0) / e * np.exp(-mu_al * filtration_mm_al)
+    return e, s / s.sum()
+
+
+def poly_sinogram(path_sinos, w_pe_list, energies, weights, severity, e_ref=60.0):
+    """y = -ln sum_k w_k exp(-sum_i r_i(E_k) t_i); each material's ratio curve
+    is normalized so the linear model is its tangent at t -> 0 (the severity
+    dial bends curvature only).  severity 0 returns the linear sinogram."""
+    if severity == 0.0:
+        return sum(path_sinos).astype(np.float32)
+    ratios = []
+    for w_pe in w_pe_list:
+        r = w_pe * (energies / e_ref) ** -3 \
+            + (1 - w_pe) * klein_nishina(energies) / klein_nishina(e_ref)
+        rs = (1.0 - severity) + severity * r
+        ratios.append(rs / np.sum(weights * rs))
+    total = np.zeros_like(path_sinos[0], dtype=np.float64)
+    for k, wk in enumerate(weights):
+        expo = sum(float(rs[k]) * t for t, rs in zip(path_sinos, ratios))
+        total += wk * np.exp(-expo)
+    return (-np.log(total)).astype(np.float32)
+
+
+# ---- Phantom: slab + one layer of metal balls, one map per material -------------
+def ball_grid_materials(recon_shape, base_n, d):
+    """Material maps on the GENERATION grid.  Ball sizes are fractions of the
+    base image size (base_n) so they do not change when the grid is enlarged;
+    the slab width is a fraction of the generation grid (that is what makes it
+    overflow the base field of view when data.gen_lateral_scale > 1)."""
+    rows, cols, slices = recon_shape
+    slab = np.zeros(recon_shape, dtype=np.float32)
+    metals = [np.zeros(recon_shape, dtype=np.float32) for _ in d['metal_values']]
+    rc, cc, zc = (rows - 1) / 2.0, (cols - 1) / 2.0, (slices - 1) / 2.0
+    half = 0.5 * d['slab_xy_frac'] * min(rows, cols)
+    half_z = 0.5 * d['slab_z_frac'] * slices
+    slab[int(rc - half):int(rc + half) + 1, int(cc - half):int(cc + half) + 1,
+         int(zc - half_z):int(zc + half_z) + 1] = d['slab_value']
+
+    pitch = d['ball_pitch_frac'] * base_n
+    radius = d['ball_radius_frac'] * base_n
+    k = int((half - 2 * radius - 2) // pitch)
+    centers = pitch * np.arange(-k, k + 1)
+    print(f'Phantom: {len(centers) ** 2} ball(s) of radius {radius:.1f} voxels, '
+          f'{len(d["metal_values"])} metal type(s)')
+    zball = (slices - 1) * d['ball_layer_z_frac']
+    rad_i = int(np.ceil(radius)) + 1
+    for i, br in enumerate(centers + rc):
+        for j, bc in enumerate(centers + cc):
+            m = (i + j) % len(d['metal_values'])
+            rr = np.arange(int(br) - rad_i, int(br) + rad_i + 1)
+            cw = np.arange(int(bc) - rad_i, int(bc) + rad_i + 1)
+            zw = np.arange(max(0, int(zball) - rad_i),
+                           min(slices, int(zball) + rad_i + 1))
+            sphere = ((rr - br)[:, None, None] ** 2 + (cw - bc)[None, :, None] ** 2
+                      + (zw - zball)[None, None, :] ** 2) <= radius ** 2
+            window = slab[np.ix_(rr, cw, zw)]
+            window[sphere] = 0.0
+            slab[np.ix_(rr, cw, zw)] = window
+            window = metals[m][np.ix_(rr, cw, zw)]
+            window[sphere] = d['metal_values'][m]
+            metals[m][np.ix_(rr, cw, zw)] = window
+    return slab, metals
+
+
+def make_model(g, lateral_scale=1.0, axial_pad=0.0):
+    """A cone or parallel model, optionally laterally enlarged / axially padded."""
+    sinogram_shape = (g['num_views'], g['num_det_rows'], g['num_det_channels'])
+    if g['model_type'] == 'cone':
+        angles = np.linspace(0, 2 * np.pi, g['num_views'], endpoint=False)
+        sdd = g['sdd_factor'] * g['num_det_channels']
+        m = mj.ConeBeamModel(sinogram_shape, angles,
+                             source_detector_dist=sdd, source_iso_dist=sdd / 2)
+        if np.max(axial_pad) > 0:
+            m.set_params(axial_pad_fraction=axial_pad)
+    else:
+        angles = np.linspace(0, np.pi, g['num_views'], endpoint=False)
+        m = mj.ParallelBeamModel(sinogram_shape, angles)
+    if lateral_scale > 1.0:
+        m.scale_recon_shape(lateral_scale, lateral_scale)
+    return m
+
+
+def central_crop_pair(a, b):
+    """Central crops of two volumes to their common shape (for error metrics)."""
+    shape = tuple(min(sa, sb) for sa, sb in zip(a.shape, b.shape))
+    def crop(v):
+        starts = [(sv - s) // 2 for sv, s in zip(v.shape, shape)]
+        return v[tuple(slice(st, st + s) for st, s in zip(starts, shape))]
+    return crop(a), crop(b)
+
+
+# ============================== the pipeline =====================================
+def main():
+    p = get_params(*regime, custom=custom)
+    print('Resolved parameters:')
+    pprint.pprint(p, sort_dicts=False)
+
+    g, d, h, r = p['geometry'], p['data'], p['hardening'], p['recon']
+
+    # Generation model: the grid the TRUE object lives on (possibly beyond the
+    # base field of view laterally and/or axially).
+    gen_model = make_model(g, lateral_scale=d['gen_lateral_scale'],
+                           axial_pad=(1.0 if d['gen_axial_overflow'] else 0.0))
+    gen_shape = gen_model.get_params('recon_shape')
+    print(f"Generation grid {gen_shape}; building the phantom and forward "
+          f"projecting each material...")
+    slab_map, metal_maps = ball_grid_materials(gen_shape, g['num_det_channels'], d)
+    path_sinos = [np.asarray(gen_model.forward_project(m), dtype=np.float64)
+                  for m in [slab_map] + metal_maps]
+    scale = d['target_max_attenuation'] / float(sum(path_sinos).max())
+    path_sinos = [t * scale for t in path_sinos]
+    ground_truth = (slab_map + sum(metal_maps)) * scale
+
+    print('Applying the polychromatic (beam hardening) model...')
+    energies, spec_w = make_spectrum(h['kvp'], h['filtration_mm_al'])
+    sino = poly_sinogram(path_sinos, [h['plastic_w_pe']] + list(h['metal_w_pe']),
+                         energies, spec_w, h['severity'])
+    if p['noise']['i0'] is not None:
+        rng = np.random.default_rng(0)
+        counts = rng.poisson(p['noise']['i0'] * np.exp(-np.float64(sino)))
+        sino = (-np.log(np.maximum(counts, 1) / p['noise']['i0'])).astype(np.float32)
+    weights = mj.gen_weights(sino, weight_type='transmission_root')
+
+    if p['display']['show_sinogram']:
+        # Nonblocking: this window stays open beside the reconstruction viewer
+        # below and becomes fully interactive once that (blocking) viewer opens.
+        mj.slice_viewer(sino, slice_axis=0, slice_label='View', block=False,
+                        title=f"Simulated sinogram {regime} "
+                              f"({g['model_type']} beam)")
+
+    # Reconstruction model: the base grid, plus any remedies the user enabled.
+    ct_model = make_model(g, lateral_scale=r['lateral_pad_scale'],
+                          axial_pad=r['axial_pad_fraction'])
+    ct_model.set_params(sharpness=r['sharpness'], snr_db=r['snr_db'])
+    print(f"Reconstruction grid {ct_model.get_params('recon_shape')}; "
+          "standard reconstruction (linear model)...")
+    recon_std, _ = ct_model.recon(sino, weights=weights,
+                                  max_iterations=r['max_iterations'])
+    recons = [ground_truth, np.asarray(recon_std)]
+    labels = ['ground truth', 'standard recon']
+
+    m = p['mar']
+    if m['use_mar']:
+        print('MAR reconstruction (plastic-metal beam hardening correction)...')
+        recon_mar = mjp.recon_plastic_metal(
+            ct_model, sino, weights, num_BH_iterations=m['num_bh_iterations'],
+            num_metal=m['num_metal'], order=m['order'], alpha=m['alpha'],
+            beta=m['beta'], gamma=m['gamma'],
+            max_iterations=r['max_iterations'])
+        recons.append(np.asarray(recon_mar))
+        labels.append('MAR recon')
+
+    # Error metrics on the overlap of each recon with the ground truth.
+    metal_floor = 0.5 * max(d['metal_values']) * scale
+    for rec, lab in zip(recons[1:], labels[1:]):
+        gt_c, rec_c = central_crop_pair(ground_truth, rec)
+        err = np.linalg.norm(rec_c - gt_c) / np.linalg.norm(gt_c)
+        plastic = (gt_c > 0) & (gt_c < metal_floor)
+        perr = (np.linalg.norm((rec_c - gt_c)[plastic])
+                / np.linalg.norm(gt_c[plastic]))
+        print(f'  {lab}: NRMSE vs ground truth = {err:.4f} '
+              f'(plastic region only: {perr:.4f})')
+
+    # The what-to-look-for guidance goes into the viewer title (and the
+    # terminal), wrapped to keep the figure header readable.
+    import textwrap
+    guidance = []
+    for tag in regime:
+        if tag in WHAT_TO_LOOK_FOR:
+            print(f'[{tag}] {WHAT_TO_LOOK_FOR[tag]}')
+            guidance.extend(textwrap.wrap(f'{tag}: {WHAT_TO_LOOK_FOR[tag]}',
+                                          width=110))
+    title = '\n'.join([f"Artifacts demo {regime} ({g['model_type']} beam)"]
+                      + guidance)
+    mj.slice_viewer(*recons, slice_label=labels, title=title,
+                    vmin=0.0, vmax=float(ground_truth.max()))
+
+
+# =========================== regimes and parameters ==============================
+def _deep_update(dst, src):
+    for key, val in src.items():
+        if isinstance(val, dict) and isinstance(dst.get(key), dict):
+            _deep_update(dst[key], val)
+        else:
+            dst[key] = val
+    return dst
+
+
+BASE_PARAMS = {
+    'geometry': dict(
+        model_type='cone',          # 'cone' or 'parallel'
+        num_views=100,              # projection views (cone: over 2*pi)
+        num_det_rows=128,           # detector rows (axial direction)
+        num_det_channels=128,       # detector channels (lateral direction)
+        sdd_factor=2.5),            # cone: SDD in units of num_det_channels
+    'data': dict(
+        gen_lateral_scale=1.0,      # >1: the true object overflows the lateral FoV
+        gen_axial_overflow=False,   # True: the object extends beyond axial coverage
+        slab_xy_frac=0.6,           # slab width, fraction of the GENERATION grid
+        slab_z_frac=0.5,            # slab height, fraction of the generation slices
+        slab_value=1.0,             # plastic attenuation at the reference energy
+        metal_values=(6.0, 4.5),    # attenuation per metal type (one ball class each)
+        ball_pitch_frac=0.12,       # ball lattice pitch, fraction of the base size
+        ball_radius_frac=0.055,     # ball radius, fraction of the base size
+        ball_layer_z_frac=0.5,      # ball layer height, fraction of the volume
+        target_max_attenuation=5.0),  # scale so the ideal sinogram peaks near this
+    'hardening': dict(
+        severity=0.0,               # 0 = linear data ... 1 = strong beam hardening
+        plastic_w_pe=0.05,          # photoelectric weight (hardening factor) ...
+        metal_w_pe=(0.8, 0.55),     # ... per material at the reference energy
+        kvp=140.0,                  # source spectrum endpoint (keV)
+        filtration_mm_al=2.0),      # aluminum filtration (mm)
+    'noise': dict(
+        i0=1.0e4),                  # photons/ray Poisson noise; None = noiseless
+    'recon': dict(
+        sharpness=1.0,              # regularization sharpness
+        snr_db=30.0,                # regularization snr_db
+        max_iterations=15,          # MBIR iterations
+        lateral_pad_scale=1.0,      # >1 = the lateral-truncation remedy (padding)
+        axial_pad_fraction=0.0),    # 0..1 or (top, bottom): the axial remedy
+    'mar': dict(
+        use_mar=False,              # also run recon_plastic_metal
+        num_metal=2,                # metal classes to segment and correct
+        order=3,                    # beam-hardening polynomial degree
+        num_bh_iterations=1,        # correction <-> reconstruction alternations
+        alpha=1.0, beta=0.002, gamma=0.1),  # see recon_plastic_metal
+    'display': dict(
+        show_sinogram=True),        # open a (nonblocking) sinogram viewer too
+}
+
+TAGS = {
+    # ---- artifact tags (one or more; they compose) ----
+    'cylinder_streaks': {
+        'data': dict(gen_lateral_scale=1.5, slab_xy_frac=0.72),
+        'recon': dict(sharpness=1.5, snr_db=35.0),
+    },
+    'beam_hardening_cupping': {     # one LARGE ball: the classic cupped profile
+        'data': dict(ball_pitch_frac=2.0, ball_radius_frac=0.12,
+                     metal_values=(6.0,)),
+        'hardening': dict(severity=0.7, metal_w_pe=(0.8,)),
+        'mar': dict(use_mar=True, num_metal=1),
+    },
+    'beam_hardening_streaks': {     # many small balls: interball dark bands
+        'data': dict(ball_pitch_frac=0.10, ball_radius_frac=0.035),
+        'hardening': dict(severity=0.7),
+        'mar': dict(use_mar=True),
+    },
+    'lateral_fov': {
+        'data': dict(gen_lateral_scale=1.5, slab_xy_frac=0.72),
+    },
+    'axial_fov': {
+        'data': dict(gen_axial_overflow=True, slab_z_frac=0.9),
+    },
+    'bga_like': {   # the real-scan mimic: truncated + hardened + dense grid
+        'data': dict(gen_lateral_scale=1.5, slab_xy_frac=0.72,
+                     ball_pitch_frac=0.12, ball_radius_frac=0.055),
+        'hardening': dict(severity=0.5),
+        'recon': dict(sharpness=1.5, snr_db=35.0),
+        'mar': dict(use_mar=True),
+    },
+    # ---- size tags (pick one; default medium) ----
+    'small': {'geometry': dict(num_views=40, num_det_rows=64,
+                               num_det_channels=64),
+              'recon': dict(max_iterations=10)},
+    'medium': {},
+    'large': {'geometry': dict(num_views=200, num_det_rows=256,
+                               num_det_channels=256)},
+    # ---- ball-density tags (pick one; regimes carry their own default) ----
+    'sparse': {'data': dict(ball_pitch_frac=0.16, ball_radius_frac=0.05)},
+    'dense': {'data': dict(ball_pitch_frac=0.10, ball_radius_frac=0.04)},
+}
+TAGS['beam_hardening'] = TAGS['beam_hardening_streaks']   # alias
+
+WHAT_TO_LOOK_FOR = {
+    'cylinder_streaks': ('transpose to the (x,z) view: fine vertical striping '
+                         'across the slab plus bright flash at the lateral edges.'
+                         "  Remedy: custom = {'recon': {'lateral_pad_scale': 1.5}}."),
+    'beam_hardening_cupping': ('axial view at the ball layer: the ball is darker '
+                               'toward its center and the slab darkens around it. '
+                               'Narrow the intensity range to see it clearly.  The MAR '
+                               'recon restores the slab level; plastic-region NRMSE is '
+                               'the fair number (the metal is reinserted as '
+                               'reconstructed).'),
+    'beam_hardening_streaks': ('axial view at the ball layer: dark bands between '
+                               'balls and a darkened slab.  Compare the MAR recon; '
+                               'plastic-region NRMSE is the fair number.'),
+    'lateral_fov': ('axial view: a bright ring at the reconstruction boundary '
+                    'and an elevated interior.'
+                    "  Remedy: custom = {'recon': {'lateral_pad_scale': 1.5}}."),
+    'axial_fov': ('transpose to (x,z): bright flash and ringing at the top and '
+                  'bottom slices.'
+                  "  Remedy: custom = {'recon': {'axial_pad_fraction': 1.0}}."),
+    'bga_like': ('truncation + hardening at once -- the uncorrected real-scan '
+                 'situation.  Explore the remedies one at a time.'),
+}
+WHAT_TO_LOOK_FOR['beam_hardening'] = WHAT_TO_LOOK_FOR['beam_hardening_streaks']
+
+
+def get_params(*tags, custom=None):
+    """Return the parameter dict for one or more regime tags.
+
+    Tags compose left to right (later tags win); ``custom`` (a possibly-nested
+    dict of the same shape) is applied last.
+
+    Artifact tags:   cylinder_streaks, beam_hardening_cupping,
+                     beam_hardening_streaks (alias: beam_hardening),
+                     lateral_fov, axial_fov, bga_like
+    Size tags:       small, medium (default), large
+    Density tags:    sparse, dense
+    """
+    import copy
+    params = copy.deepcopy(BASE_PARAMS)
+    for tag in tags:
+        if tag not in TAGS:
+            raise ValueError(f'unknown tag {tag!r}; valid tags: {sorted(TAGS)}')
+        _deep_update(params, copy.deepcopy(TAGS[tag]))
+    if custom:
+        _deep_update(params, custom)
+    return params
+
+
+if __name__ == '__main__':
+    main()

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -302,6 +302,12 @@ def _argmin_3d(x):
     return (view, row, col), per_view_min[view]
 
 
+# Minimum NORMALIZED metal-sinogram value for a pixel to be eligible for a residual-positivity
+# constraint (the metal estimates are normalized to max 1 before the fit, so this is relative).
+# See _find_most_violated_constraints for why near-zero-support pixels must be excluded.
+_METAL_SUPPORT_FLOOR = 1e-3
+
+
 def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_est, theta, H_exponent_list, num_cross_terms, view_mask=None):
     """
     Compute the most violated constraints for the beam hardening model.
@@ -314,6 +320,15 @@ def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_
     the constraints.  When the sinograms are device-form (view-sharded, possibly zero-padded on the view
     axis), ``view_mask`` (1 on real views, 0 on padded, broadcasting over the sinogram) excludes the
     padded views from the argmin so a padded entry is never selected as a constraint.
+
+    The residual argmin is further restricted to pixels where some metal estimate exceeds
+    ``_METAL_SUPPORT_FLOOR``: where every metal estimate is (near) zero the row H_m[i,:] is (near)
+    zero, so no θ can move that residual and the constraint is unactionable -- vacuous when
+    y[i] ≥ 0, and STRUCTURALLY INFEASIBLE when y[i] < 0 (which noisy measured sinograms routinely
+    contain on air rays from log-domain noise).  One such selected pixel makes OSQP declare the
+    whole QP primal infeasible, and its sentinel "solution" used to silently poison theta and
+    collapse the corrected plastic to ~0.  Near-zero rows are almost as bad: the constraint then
+    demands metal-polynomial coefficients of order y/m.
 
     Returns:
         idx_min_Sp (tuple of int): (view, row, col) of the smallest Sp entry (per-axis ints; see
@@ -342,7 +357,15 @@ def _find_most_violated_constraints(measured_sino, plastic_sino_est, metal_sino_
     # value at a real position is the same in the masked and unmasked arrays (the mask only alters
     # padded entries), so no separate read is needed.
     Sp_masked = Sp if view_mask is None else jnp.where(view_mask, Sp, jnp.inf)
-    ymSm_masked = y_minus_Sm if view_mask is None else jnp.where(view_mask, y_minus_Sm, jnp.inf)
+
+    # Residual argmin restricted to the metal support (see the docstring): pixels where every metal
+    # estimate is <= the floor cannot be moved by theta, so they must never become constraints.
+    # Padded views have all-zero metal estimates, so this mask also excludes them -- no separate
+    # view_mask application is needed here.
+    metal_support = jnp.zeros_like(y_minus_Sm, dtype=bool)
+    for metal in metal_sino_est:
+        metal_support = metal_support | (metal > _METAL_SUPPORT_FLOOR)
+    ymSm_masked = jnp.where(metal_support, y_minus_Sm, jnp.inf)
     idx_min_Sp, v_min_Sp = _argmin_3d(Sp_masked)
     idx_min_residual, v_min_residual = _argmin_3d(ymSm_masked)
 
@@ -367,7 +390,8 @@ def _estimate_BH_model_params_using_OSQP(P, q, A, u):
         u (jnp.ndarray): Right-hand side vector for the inequality constraints.
 
     Returns:
-        jnp.ndarray: Solution vector θ.
+        jnp.ndarray or None: Solution vector θ, or ``None`` when the constrained solve fails
+        (a non-solved OSQP status, or a non-finite solution vector).
     """
     # Convert to numpy for linalg.solve and OSQP
     P_numpy = np.asarray(P)
@@ -392,9 +416,17 @@ def _estimate_BH_model_params_using_OSQP(P, q, A, u):
     solver = osqp.OSQP()
     solver.setup(P=P_sparse, q=q_numpy, A=A_sparse, l=None, u=u_numpy, alpha=1.0, verbose=0)
     result = solver.solve()
-    theta = jnp.asarray(result.x, dtype=jnp.float32)
 
-    return theta
+    # OSQP reports failure through the status field, NOT by raising: on an infeasible or unsolved
+    # QP it fills result.x with a no-solution sentinel (2143289344.0 -- the float32-NaN bit pattern
+    # as a value), which is FINITE and would silently poison every downstream use of theta.
+    # Accept only a solved status ('solved' / 'solved inaccurate') with finite values.
+    status = str(result.info.status).strip().lower()
+    theta = np.asarray(result.x, dtype=np.float64)
+    if not status.startswith('solved') or not np.all(np.isfinite(theta)):
+        return None
+
+    return jnp.asarray(theta, dtype=jnp.float32)
 
 def _compute_entry_for_OSQP(plastic_sino_est, metal_sino_est, measured_sino, H_exponent_list, num_cross_terms, alpha, beta):
     """Compute entries for OSQP quadratic programming solver."""
@@ -509,7 +541,11 @@ def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H
             row_m = _get_row_H(idx_min_residual, plastic_sino_est, metal_sino_est, H_exponent_list)
             # Positive row_m[dp:] to ensure y-Hmθm >= 0
             A_m = jnp.concatenate([jnp.zeros(dp), row_m[dp:]])
-            u_m = jnp.array([measured_sino[idx_min_residual]])
+            # RHS clamped at 0: the metal-only contribution H_m θ_m is a physical (nonnegative)
+            # attenuation, so its tightest meaningful upper bound is max(y, 0).  A raw negative
+            # measurement (log-domain noise) would force the metal polynomial NEGATIVE at this
+            # pixel's metal values -- for small values that means huge negative coefficients.
+            u_m = jnp.array([jnp.maximum(measured_sino[idx_min_residual], 0.0)])
             A = jnp.vstack([A, A_m[None, :]])
             u = jnp.concatenate([u, u_m])
             C_m.append(idx_min_residual)
@@ -517,7 +553,16 @@ def _estimate_BH_model_params(plastic_sino_est, metal_sino_est, measured_sino, H
         # Early exit if both constraints are satisfied (within tolerances)
         if (v_min_Sp >= tolerance) and (v_min_residual >= tolerance):
             break
-        theta = _estimate_BH_model_params_using_OSQP(P, q, A, u)
+        theta_new = _estimate_BH_model_params_using_OSQP(P, q, A, u)
+        if theta_new is None:
+            # Defensive: with the support-restricted constraint selection the QP is feasible by
+            # construction (the two constraint families act on disjoint theta blocks, each
+            # satisfiable), so a solver failure signals numerical trouble.  Keep the last good
+            # theta rather than propagating OSQP's failure sentinel into the correction.
+            warnings.warn("OSQP failed to solve the constrained beam-hardening fit; keeping the "
+                          "parameters from the previous constraint iteration.", RuntimeWarning)
+            break
+        theta = theta_new
     return theta
 
 

--- a/mbirjax/preprocess/mar.py
+++ b/mbirjax/preprocess/mar.py
@@ -160,7 +160,8 @@ def _generate_metal_exponent_list(num_metal, max_order):
     return combinations
 
 
-def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model):
+def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model,
+                                        radial_margin=None, top_margin=None, bottom_margin=None):
     """
     Segment plastic and metal regions from a reconstruction, project them,
     and return the unnormalized sinogram p, m0, m1, ... for beam hardening modeling.
@@ -169,6 +170,8 @@ def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model):
         recon (jnp.ndarray): Reconstructed image.
         num_metal (int): Number of metal types to segment.
         ct_model: Forward projection model with a `.forward_project()` method.
+        radial_margin, top_margin, bottom_margin (int or None, optional): Segmentation mask
+            margins; None (default) = size-relative (see segment_plastic_metal).
 
     Returns:
         plastic_sino_est (jnp.ndarray): Unnormalized plastic sino estimation.
@@ -193,7 +196,8 @@ def _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model):
     # plastic_scale: Scaling factor for the plastic region.
     # metal_scales: List of scaling factors for each metal region.
     plastic_mask, metal_masks, plastic_scale, metal_scales = mjp.segment_plastic_metal(
-        recon, num_metal=num_metal, valid_mask=valid_mask, num_real_slices=pl.real_size)
+        recon, num_metal=num_metal, radial_margin=radial_margin, top_margin=top_margin,
+        bottom_margin=bottom_margin, valid_mask=valid_mask, num_real_slices=pl.real_size)
 
     # --- Forward project and scale plastic ---
     # The masks/recon are already sharded, so forward_project consumes them with no further movement.
@@ -612,7 +616,8 @@ def _estimate_plastic_scaling(plastic_sino_est, metal_sino_est, measured_sino, p
                                                     jnp.where(condition, plastic_sino_corrected, 0.0))
     return plastic_sino_scale
 
-def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, order=3, alpha=1, beta=0.002, gamma=0.1, num_constraint_update_iter=10):
+def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, order=3, alpha=1, beta=0.002, gamma=0.1, num_constraint_update_iter=10,
+                               radial_margin=None, top_margin=None, bottom_margin=None):
     """
     This function corrects the measured sinogram of an object with plastic and multiple metal components by fitting a
     beam hardening model to the sinogram and removing the metal contributions.
@@ -628,6 +633,8 @@ def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, orde
         beta (float, optional): Regularization strength for ridge regression. Defaults to 0.002.
         gamma (float, optional): Stabilization factor. Defaults to 0.1.
         num_constraint_update_iter (int, optional): Number of iterations for updating constraints. Defaults to 10.
+        radial_margin, top_margin, bottom_margin (int or None, optional): Segmentation mask margins;
+            None (default) = size-relative (see segment_plastic_metal).
 
     Returns:
         jnp.ndarray: Beam-hardening corrected sinogram of the same shape as `measured_sino`.
@@ -666,7 +673,9 @@ def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, orde
     num_real_pixels = pl.real_size * (measured_sino.size // measured_sino.shape[ax])
 
     # Get normalized sinogram p and [m_0, m_1, ...] (view-sharded; forward_project handles placement).
-    plastic_sino_est, metal_sino_est = _est_plastic_metal_sinos_from_recon(recon, num_metal, ct_model)
+    plastic_sino_est, metal_sino_est = _est_plastic_metal_sinos_from_recon(
+        recon, num_metal, ct_model, radial_margin=radial_margin, top_margin=top_margin,
+        bottom_margin=bottom_margin)
     plastic_sino_scale = jnp.max(jnp.abs(plastic_sino_est))   # max over padded 0s is unaffected
     metal_sino_scale = [jnp.max(jnp.abs(arr)) for arr in metal_sino_est]
     # JAX division does not raise on 0/0 -- an empty (all-zero) plastic or metal estimate would silently
@@ -705,7 +714,8 @@ def correct_sino_plastic_metal(ct_model, measured_sino, recon, num_metal=1, orde
 
 def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constraint_update_iter=10, stop_threshold_change_pct=0.2,
                         num_metal=1, order=3, alpha=1, beta=0.002, gamma=0.1, verbose=0, output_sharded=False,
-                        max_iterations=15, logfile_path='~/.mbirjax/logs/recon.log'):
+                        max_iterations=15, logfile_path='~/.mbirjax/logs/recon.log',
+                        radial_margin=None, top_margin=None, bottom_margin=None):
     """
     Perform iterative metal artifact reduction using plastic-metal beam hardening correction.  If num_metal is 0,
     then this performs a standard MBIR recon.
@@ -735,6 +745,9 @@ def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constr
         max_iterations (int, optional): Maximum MBIR iterations per reconstruction pass. Defaults to 15.
         logfile_path (str, optional): Same as in the TomographyModel.recon() method.  The BH passes'
             logs are merged into this single file, each under a section header.
+        radial_margin, top_margin, bottom_margin (int or None, optional): Segmentation mask margins
+            used when classifying plastic/metal; None (default) = size-relative
+            (see segment_plastic_metal).
 
     Returns:
          numpy or jax array: The final corrected reconstruction after iterative beam hardening
@@ -796,7 +809,8 @@ def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constr
             # Estimate Corrected Sinogram
             if verbose >= 1:
                 print(f"\n************ Correct sino plastic metal {i + 1}  **************")
-            corrected_sinogram = correct_sino_plastic_metal(ct_model, sino, recon, num_metal=num_metal, order=order, alpha=alpha, beta=beta, gamma=gamma, num_constraint_update_iter=num_constraint_update_iter)
+            corrected_sinogram = correct_sino_plastic_metal(ct_model, sino, recon, num_metal=num_metal, order=order, alpha=alpha, beta=beta, gamma=gamma, num_constraint_update_iter=num_constraint_update_iter,
+                                                            radial_margin=radial_margin, top_margin=top_margin, bottom_margin=bottom_margin)
 
             # Reconstruct Corrected Sinogram
             if verbose >= 1:
@@ -808,7 +822,9 @@ def recon_plastic_metal(ct_model, sino, weights, num_BH_iterations=3, num_constr
 
             if verbose >= 2:
                 print(f"\n************ BH Iteration {i + 1}: Display plastic and metal mask **************")
-                plastic_mask, metal_masks, plastic_scale, metal_scales = mjp.segment_plastic_metal(recon, num_metal)
+                plastic_mask, metal_masks, plastic_scale, metal_scales = mjp.segment_plastic_metal(
+                    recon, num_metal, radial_margin=radial_margin, top_margin=top_margin,
+                    bottom_margin=bottom_margin)
                 labels = ['Plastic Mask'] + [f'Metal {j + 1} Mask' for j in range(len(metal_masks))]
                 mj.slice_viewer(plastic_mask, *metal_masks, vmin=0, vmax=1.0,
                                 slice_label=labels,

--- a/mbirjax/preprocess/segmentation.py
+++ b/mbirjax/preprocess/segmentation.py
@@ -311,7 +311,7 @@ def _otsu_thresholds_dp(hist, num_thresholds):
     return boundaries[::-1]
 
 
-def segment_plastic_metal(recon, num_metal, radial_margin=10, top_margin=10, bottom_margin=10,
+def segment_plastic_metal(recon, num_metal, radial_margin=None, top_margin=None, bottom_margin=None,
                           valid_mask=None, num_real_slices=None):
     """
     Segment a reconstruction into plastic and multiple metal masks using multi-threshold Otsu.
@@ -326,9 +326,14 @@ def segment_plastic_metal(recon, num_metal, radial_margin=10, top_margin=10, bot
     Args:
         recon (np.ndarray or jax.Array): Reconstructed volume array (host, single-device, or sharded).
         num_metal (int): Number of metal materials to segment.
-        radial_margin (int, optional): Margin in pixels to subtract from the cylindrical mask radius.
-        top_margin (int, optional): Number of slices to mask out from the top of the volume.
-        bottom_margin (int, optional): Number of slices to mask out from the bottom of the volume.
+        radial_margin (int or None, optional): Margin in pixels to subtract from the cylindrical mask
+            radius.  None (default) uses a size-relative margin, max(2, min(10, min(rows, cols) // 25)):
+            identical to the former fixed 10 for volumes 250 pixels and wider, and proportionally
+            smaller for small volumes (where a fixed 10 would cut real object).
+        top_margin (int or None, optional): Number of slices to mask out from the top of the volume.
+            None (default) uses max(2, min(10, num_slices // 25)) with the same rationale.
+        bottom_margin (int or None, optional): Number of slices to mask out from the bottom.
+            None (default) as for top_margin.
         valid_mask (jax array or None, optional): Broadcastable boolean mask, True on real voxels.
         num_real_slices (int or None, optional): Real slice count (see ``apply_cylindrical_mask``).
 
@@ -341,6 +346,16 @@ def segment_plastic_metal(recon, num_metal, radial_margin=10, top_margin=10, bot
     """
     if num_metal <= 0:
         raise ValueError("num_metal must be positive")
+
+    # Size-relative default margins: the former fixed 10 at production sizes, smaller for small
+    # volumes so the mask never carves off a large fraction of the field of view.
+    num_slices = num_real_slices if num_real_slices is not None else recon.shape[2]
+    if radial_margin is None:
+        radial_margin = max(2, min(10, min(recon.shape[0], recon.shape[1]) // 25))
+    if top_margin is None:
+        top_margin = max(2, min(10, num_slices // 25))
+    if bottom_margin is None:
+        bottom_margin = max(2, min(10, num_slices // 25))
 
     # Remove any flash from the boundary of the recon
     recon = mjp.apply_cylindrical_mask(recon, radial_margin=radial_margin, top_margin=top_margin,

--- a/mbirjax/viewer.py
+++ b/mbirjax/viewer.py
@@ -92,7 +92,7 @@ class SliceViewer:
     """
 
     def __init__(self, *datasets, data_dicts=None, title='', vmin=None, vmax=None, slice_label=None,
-                 slice_axis=None, cmap='gray', show_instructions=True):
+                 slice_axis=None, cmap='gray', show_instructions=True, block=True):
         self.datasets = [np.asarray(dataset) for dataset in datasets]  # Convert to numpy arrays to avoid problems with sharded arrays
         self.n_volumes = len(datasets)
         self.title = title
@@ -136,7 +136,7 @@ class SliceViewer:
         self._clear_image_selection()
         self._difference_image_dicts = [None] * self.n_volumes  # Entries:  comparison_index, use_abs, prev_label
         easygui.boxes.global_state.prop_font_line_length = 80
-        self.show()
+        self.show(block=block)
 
     def _clear_image_selection(self):
         self._image_selection_dict = {'selecting_image': False, 'baseline_index': -1}
@@ -1028,18 +1028,27 @@ class SliceViewer:
             self._menu_texts.clear()
             self.fig.canvas.draw_idle()
 
-    def show(self):
-        """Display the viewer window and block execution until the window is closed.
+    def show(self, block=True):
+        """Display the viewer window; block until closed when ``block`` is True.
 
-        Close this figure BY OBJECT after the window closes, so its TkAgg widgets are torn down
-        deterministically.  (Closing by number re-created a blank phantom figure when the window-close
-        event had already removed the real one from matplotlib's registry, leaving the real figure's
-        toolbar widgets un-closed.)  slice_viewer then drops the viewer and runs gc on the main thread,
-        so the toolbar PhotoImages are finalized here rather than later by a background-thread GC --
-        the source of "main thread is not in main loop".
+        Blocking path: close this figure BY OBJECT after the window closes, so its TkAgg widgets
+        are torn down deterministically.  (Closing by number re-created a blank phantom figure when
+        the window-close event had already removed the real one from matplotlib's registry, leaving
+        the real figure's toolbar widgets un-closed.)  slice_viewer then drops the viewer and runs
+        gc on the main thread, so the toolbar PhotoImages are finalized here rather than later by a
+        background-thread GC -- the source of "main thread is not in main loop".
+
+        Nonblocking path (``block=False``): the window is drawn and left open; it becomes fully
+        interactive once a subsequent blocking viewer (or ``plt.show()``) runs the GUI event loop,
+        and that blocking call returns when the user closes ALL open windows.  The caller (see
+        ``slice_viewer``) must keep the viewer object alive, or its widgets stop responding.
         """
-        plt.show()
-        plt.close(self.fig)
+        if block:
+            plt.show()
+            plt.close(self.fig)
+        else:
+            self.fig.show()
+            self.fig.canvas.draw_idle()
 
 
 def _choose_array_name(array_names, shapes, file_path):
@@ -1057,8 +1066,11 @@ def _choose_array_name(array_names, shapes, file_path):
     return choice
 
 
+_NONBLOCKING_VIEWERS = []   # keeps block=False viewers (and their Tk widgets) alive
+
+
 def slice_viewer(*datasets, data_dicts=None, title='', vmin=None, vmax=None, slice_label=None,
-                 slice_axis=None, cmap='gray', show_instructions=True):
+                 slice_axis=None, cmap='gray', show_instructions=True, block=True):
     """
     Launch an interactive viewer for inspecting one or more 2D or 3D image arrays.
 
@@ -1084,9 +1096,13 @@ def slice_viewer(*datasets, data_dicts=None, title='', vmin=None, vmax=None, sli
         slice_axis (int or list of int, optional): Axis along which to slice (0, 1, or 2). Defaults to the last axis (2).
         cmap (str, optional): Colormap to use. Defaults to "gray".
         show_instructions (bool, optional): Whether to display usage instructions in the figure. Defaults to True.
+        block (bool, optional): If True (default), block until the window is closed.  If False, leave
+            the window open and return immediately -- useful for showing, e.g., a sinogram next to a
+            reconstruction.  A nonblocking window becomes fully interactive when the next blocking
+            slice_viewer runs, and that blocking call returns when ALL open windows are closed.
 
     Notes:
-        - This function blocks execution until the viewer window is closed.
+        - With ``block=True`` (default) this function blocks until the viewer window is closed.
         - Right-click an image to access a context menu with options such as axis transposition and file loading.
         - Right-click the intensity slider (if using TkAgg backend) to manually set display range bounds.
         - Press 'h' to show help overlay. Press 'Esc' to clear overlays or reset ROI selections.
@@ -1098,12 +1114,21 @@ def slice_viewer(*datasets, data_dicts=None, title='', vmin=None, vmax=None, sli
     """
     viewer = SliceViewer(*datasets, data_dicts=data_dicts, title=title, vmin=vmin, vmax=vmax,
                          slice_label=slice_label,  slice_axis=slice_axis, cmap=cmap,
-                         show_instructions=show_instructions)
-    # The viewer blocks until its window closes.  Matplotlib's TkAgg backend leaves orphaned tkinter
-    # objects (toolbar icons/variables) that plt.close does not fully release; collect them now, on
-    # the main thread, so a later automatic GC -- e.g. during a sharded recon, whose reference-cycle
-    # arrays trigger gen-2 collection -- does not finalize them with no Tk mainloop running and print
-    # "main thread is not in main loop".  (Interim; a viewer overhaul is planned.)
+                         show_instructions=show_instructions, block=block)
+    if not block:
+        # Keep the viewer (and its Tk widgets) alive; the next BLOCKING call adopts it into the
+        # shared GUI event loop and tears it down after all windows close.
+        _NONBLOCKING_VIEWERS.append(viewer)
+        return
+    # The viewer blocked until every open window (including any earlier nonblocking ones) closed.
+    # Matplotlib's TkAgg backend leaves orphaned tkinter objects (toolbar icons/variables) that
+    # plt.close does not fully release; collect them now, on the main thread, so a later automatic
+    # GC -- e.g. during a sharded recon, whose reference-cycle arrays trigger gen-2 collection --
+    # does not finalize them with no Tk mainloop running and print "main thread is not in main
+    # loop".  (Interim; a viewer overhaul is planned.)
+    for nb in _NONBLOCKING_VIEWERS:
+        plt.close(nb.fig)
+    _NONBLOCKING_VIEWERS.clear()
 
     # Apply del before gc.collect so the viewer↔Tk reference cycle is unreachable and gets finalized here,
     # on the main thread, not by a later GC mid-recon.

--- a/tests/sharding/test_mar.py
+++ b/tests/sharding/test_mar.py
@@ -16,7 +16,9 @@ import mbirjax as mj
 import mbirjax.preprocess as mjp
 from mbirjax.preprocess.mar import (_argmin_3d, _correct_plastic_sinogram,
                                     _est_plastic_metal_sinos_from_recon,
-                                    _estimate_BH_model_params, _generate_metal_exponent_list)
+                                    _estimate_BH_model_params, _estimate_BH_model_params_using_OSQP,
+                                    _find_most_violated_constraints, _generate_metal_exponent_list,
+                                    _METAL_SUPPORT_FLOOR)
 from conftest import preferred_devices, assert_sharded_allclose
 
 # 31 views and 25 detector rows -> 25 recon slices: BOTH the view and slice axes pad at 3 devices,
@@ -160,6 +162,75 @@ class TestCorrectSinoPlasticMetal(unittest.TestCase):
         measured = np.array(model.forward_project(phantom))
         with self.assertRaisesRegex(ValueError, "plastic"):
             mjp.mar.correct_sino_plastic_metal(model, measured, phantom, num_metal=1)
+
+
+class TestConstraintSelectionRobustness(unittest.TestCase):
+    """Noisy measured sinograms have NEGATIVE pixels on air rays (log-domain noise).  Selecting one
+    as a residual-positivity constraint where the metal estimates are zero poses ``0 <= y < 0`` --
+    structurally infeasible -- and OSQP's infeasibility sentinel x (2143289344.0: the float32-NaN
+    bit pattern as a value, which IS finite) then silently replaced theta and collapsed the
+    corrected plastic to ~0 (the demo_10_artifacts 'beam_hardening_cupping' num_metal=1 collapse).
+    These tests pin the three fix layers: support-restricted constraint selection, the RHS clamp
+    at 0, and the OSQP solver-status guard."""
+
+    @staticmethod
+    def _fit_inputs():
+        """Tiny fit inputs (p, [m], y) with y = 2 p + 1.5 m exactly, metal support on two pixels,
+        one sub-floor metal pixel, and the most negative y pixel OFF the metal support."""
+        shape = (4, 5, 6)
+        rng = np.random.default_rng(3)
+        p = rng.uniform(0.1, 1.0, shape).astype(np.float32)
+        m = np.zeros(shape, np.float32)
+        m[2, 1, 1], m[2, 1, 2] = 1.0, 0.5
+        m[0, 0, 1] = 0.1 * _METAL_SUPPORT_FLOOR          # sub-floor: not eligible support
+        y = (2.0 * p + 1.5 * m).astype(np.float32)
+        y[0, 0, 0] = -0.5                                # air-ray noise pixel; m == 0 there
+        return p, m, y
+
+    def test_residual_argmin_restricted_to_metal_support(self):
+        """The residual-constraint argmin must land on a pixel with real metal support, even when
+        the globally most negative residual sits off support (the infeasible-constraint trap)."""
+        p, m, y = self._fit_inputs()
+        h_exponents, num_cross = _h_exponent_list(1, order=3)
+        theta = jnp.zeros(len(h_exponents), jnp.float32)     # Sm == 0, so y - Sm == y
+        _, _, idx_res, v_res = _find_most_violated_constraints(
+            jnp.asarray(y), jnp.asarray(p), [jnp.asarray(m)], theta, h_exponents, num_cross)
+        support = m > _METAL_SUPPORT_FLOOR
+        self.assertLess(y.min(), 0)                                              # the trap exists...
+        self.assertFalse(support[np.unravel_index(y.argmin(), y.shape)])         # ...and is off support
+        self.assertTrue(support[idx_res])
+        self.assertEqual(float(v_res), float(y[support].min()))
+
+    def test_osqp_infeasible_returns_none(self):
+        """An infeasible QP (0 * theta <= -1) must yield None, not OSQP's finite sentinel vector."""
+        theta = _estimate_BH_model_params_using_OSQP(
+            jnp.eye(2), jnp.zeros(2), jnp.zeros((1, 2)), jnp.array([-1.0]))
+        self.assertIsNone(theta)
+
+    def test_negative_off_support_pixel_does_not_poison_theta(self):
+        """End to end through _estimate_BH_model_params: with the most negative measured pixel off
+        the metal support, theta must come out finite and O(1).  Before the fix this exact setup
+        made OSQP declare the QP primal infeasible and theta became the 2.14e9 sentinel."""
+        p, m, y = self._fit_inputs()
+        h_exponents, num_cross = _h_exponent_list(1, order=3)
+        theta = np.asarray(_estimate_BH_model_params(
+            jnp.asarray(p), [jnp.asarray(m)], jnp.asarray(y), h_exponents, num_cross,
+            alpha=1, beta=0.002, num_constraint_update_iter=5))
+        self.assertTrue(np.isfinite(theta).all())
+        self.assertLess(np.max(np.abs(theta)), 100.0)
+
+    def test_negative_measurement_on_support_cannot_explode_theta(self):
+        """A negative measured pixel ON thin metal support (m = 0.02): unclamped, the constraint
+        H_m theta <= y < 0 demands theta_3 <= y/m ~ -25 and the metal polynomial explodes; with the
+        RHS clamped at 0 it only asks the polynomial to vanish there, so theta stays O(1)."""
+        p, m, y = self._fit_inputs()
+        m[0, 0, 0] = 0.02                                # thin but eligible support at y = -0.5
+        h_exponents, num_cross = _h_exponent_list(1, order=3)
+        theta = np.asarray(_estimate_BH_model_params(
+            jnp.asarray(p), [jnp.asarray(m)], jnp.asarray(y), h_exponents, num_cross,
+            alpha=1, beta=0.002, num_constraint_update_iter=5))
+        self.assertTrue(np.isfinite(theta).all())
+        self.assertLess(np.max(np.abs(theta)), 10.0)
 
 
 class TestReconPlasticMetalContract(unittest.TestCase):


### PR DESCRIPTION
**Nonblocking slice viewer, MAR segmentation and robustness fixes, and an artifacts demo**

**Note:** the plans/directory and all the files from it have been moved to a separate repo `mbirjax_plans`.

Four changes from the streak-artifact study:

**PRIMARY:**

- **Fix for a `num_metal=1` plastic collapse:** The beam-hardening fit anchors its model by adding constraints at the sinogram pixels where the model is most violated. With a single metal, that search could land on a ray that never passes through metal at all — an air ray whose measured value is slightly negative from noise in the log data. Such a pixel demands the impossible (negative attenuation from a nonnegative model), so the constrained fit has no solution. The OSQP solver doesn't raise an error in that case: it returns a status flag plus a placeholder "solution" full of a large junk number, and the code used those junk values as the fitted coefficients. With garbage coefficients, the plastic part of the corrected sinogram came out near zero — the plastic simply vanished from the reconstruction. The fix closes all three doors: constraint pixels are now chosen only from rays that actually cross metal, the constraint bounds are clamped so noise can't demand negative attenuation, and the solver's status is checked — on a failed solve the previous coefficients are kept (with a warning) instead of the placeholder values. Regression tests added. On a clean synthetic single-metal case, the corrected plastic NRMSE improves from ~1.0 (plastic erased) to ~0.09 — better than the uncorrected reconstruction.

**To verify:** copy `plans/experiments/sharpness_schedule/verify_artifacts_pr.py` from the mbirjax_plans repo anywhere and run it (no arguments, a few minutes on CPU) once with prerelease installed and once with this branch: three checks — the viewer parameter, the segmentation mask radius at 64³, and the single-metal MAR plastic NRMSE — each print an OLD/NEW verdict and should all flip. For the interactive check, run `demo/demo_10_artifacts.py` as shipped.

**SECONDARY:**

- **slice_viewer gains `block=False`** (default unchanged): a nonblocking window stays open beside the next blocking viewer — e.g. a sinogram beside a reconstruction.
- **Size-relative MAR segmentation margins:** `segment_plastic_metal`'s fixed 10-voxel radial/top/bottom margins carved off a large fraction of small volumes (at 64³ the mask cut the object's corners, which the correction then zeroed). Defaults are now `max(2, min(10, size // 25))` per axis — identical for volumes ≥250 voxels wide — with the margins passed through `recon_plastic_metal` / `correct_sino_plastic_metal` for explicit control.
- **`demo/demo_10_artifacts.py`:** a regime-driven demo (field-of-view truncation, one/two-metal beam hardening, and combinations × size × ball density) showing each artifact, the standard vs MAR reconstructions, and which parameter remedies it.

🤖 Generated with [[Claude Code](https://claude.com/claude-code)](https://claude.com/claude-code)